### PR TITLE
feat: spinner verbs as ad placement + status line fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "vibeads",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Contextual dev tool discovery for Claude Code — powered by a16z portfolio",
   "type": "module",
   "bin": {
-    "vibeads": "./bin/vibeads.js"
+    "vibeads": "bin/vibeads.js"
   },
   "files": [
     "bin/",
@@ -26,6 +26,6 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/pooriaarab/vibeads.git"
+    "url": "git+https://github.com/pooriaarab/vibeads.git"
   }
 }

--- a/src/install.js
+++ b/src/install.js
@@ -91,9 +91,28 @@ export async function init() {
     command: `node ${join(VIBEADS_DIR, "src/statusline.js")}`,
   };
 
+  // Replace spinner verbs with ad copy from portfolio
+  const portfolioPath = join(__dirname, "data/portfolio.json");
+  if (existsSync(portfolioPath)) {
+    const portfolio = JSON.parse(readFileSync(portfolioPath, "utf-8"));
+    const adVerbs = portfolio.companies.map((c) => c.spinnerCopy);
+    // Save original spinnerVerbs so we can restore on uninstall
+    if (settings.spinnerVerbs) {
+      writeFileSync(
+        join(VIBEADS_DIR, "original-spinner-verbs.json"),
+        JSON.stringify(settings.spinnerVerbs)
+      );
+    }
+    settings.spinnerVerbs = {
+      mode: "replace",
+      verbs: adVerbs,
+    };
+  }
+
   // Write settings back
   writeFileSync(CLAUDE_SETTINGS, JSON.stringify(settings, null, 2));
   console.log("  Added hooks to ~/.claude/settings.json");
+  console.log("  Replaced spinner verbs with a16z portfolio ads");
 
   // Create initial config
   const config = {

--- a/src/statusline.js
+++ b/src/statusline.js
@@ -34,12 +34,14 @@ function render() {
 
   const company = rec.company;
   const speedrunBadge = company.speedrun ? " [Speedrun]" : "";
+  const url = company.website + "?ref=vibeads";
 
+  // Line 1: Company name + one-liner (no duplication)
   console.log(
-    `\x1b[36m${company.name}\x1b[0m\x1b[90m${speedrunBadge} (a16z)\x1b[0m -- ${company.statusLineCopy}`
+    `\x1b[36m${company.name}\x1b[0m\x1b[90m${speedrunBadge} (a16z)\x1b[0m -- ${company.oneLiner}`
   );
 
-  const url = company.website + "?ref=vibeads";
+  // Line 2: Clickable link using OSC 8 (Cmd+click in iTerm2/Kitty/WezTerm)
   console.log(
     `\x1b[90m  \x1b]8;;${url}\x07${url}\x1b]8;;\x07\x1b[0m`
   );

--- a/src/uninstall.js
+++ b/src/uninstall.js
@@ -26,8 +26,17 @@ export async function uninstall() {
       delete settings.statusLine;
     }
 
+    // Restore original spinner verbs
+    const originalVerbsPath = join(VIBEADS_DIR, "original-spinner-verbs.json");
+    if (existsSync(originalVerbsPath)) {
+      settings.spinnerVerbs = JSON.parse(readFileSync(originalVerbsPath, "utf-8"));
+    } else {
+      delete settings.spinnerVerbs;
+    }
+
     writeFileSync(CLAUDE_SETTINGS, JSON.stringify(settings, null, 2));
     console.log("  Removed hooks from ~/.claude/settings.json");
+    console.log("  Restored original spinner verbs");
   }
 
   if (existsSync(VIBEADS_DIR)) {


### PR DESCRIPTION
## Summary

- Replace Claude Code spinner verbs ("Doodling...", "Smooshing...") with a16z portfolio ad copy
- 20 data-driven, comparative ads rotate in the spinner
- Saves/restores original spinner verbs on uninstall
- Fix status line duplication bug (was showing company name twice)
- Bump to v0.2.0

## Verified working

See screenshot: spinner now shows "GPT-4 API: $30/M tokens. Mistral: $8/M. Open-weight models free to self-host..."

🤖 Generated with [Claude Code](https://claude.com/claude-code)