### PR TITLE
feat: contextual dynamic spinner verbs

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vibeads",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Contextual dev tool discovery for Claude Code — powered by a16z portfolio",
   "type": "module",
   "bin": {

--- a/src/hooks/post-tool.js
+++ b/src/hooks/post-tool.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-import { writeFileSync, mkdirSync, existsSync } from "fs";
+import { readFileSync, writeFileSync, mkdirSync, existsSync } from "fs";
 import { join } from "path";
 import { homedir } from "os";
 import { matchKeyword } from "../src/matcher/keyword.js";
@@ -8,6 +8,7 @@ import { recordImpression } from "../src/tracker/impressions.js";
 
 const VIBEADS_DIR = join(homedir(), ".vibeads");
 const CURRENT_REC = join(VIBEADS_DIR, "current-recommendation.json");
+const CLAUDE_SETTINGS = join(homedir(), ".claude", "settings.json");
 
 let input = "";
 process.stdin.setEncoding("utf-8");
@@ -54,6 +55,9 @@ function handlePostToolUse(hookInput) {
     `${hookInput.tool_name}: ${summarizeTrigger(hookInput)}`
   );
 
+  // Update spinner verb to match the current context
+  updateSpinnerVerb(match);
+
   // Tier 4: Return additionalContext so Claude can mention the tool
   // Only do this occasionally (1 in 5 matches) to avoid being annoying
   const shouldInjectContext = Math.random() < 0.2;
@@ -66,6 +70,32 @@ function handlePostToolUse(hookInput) {
   }
 
   process.exit(0);
+}
+
+function updateSpinnerVerb(match) {
+  try {
+    if (!existsSync(CLAUDE_SETTINGS)) return;
+    const settings = JSON.parse(readFileSync(CLAUDE_SETTINGS, "utf-8"));
+
+    // Load full portfolio for variety
+    const portfolioPath = join(VIBEADS_DIR, "src", "data", "portfolio.json");
+    if (!existsSync(portfolioPath)) return;
+    const portfolio = JSON.parse(readFileSync(portfolioPath, "utf-8"));
+
+    // Put the matched company's ad first, then fill with others
+    const matchedVerb = match.spinnerCopy;
+    const otherVerbs = portfolio.companies
+      .filter((c) => c.slug !== match.slug)
+      .map((c) => c.spinnerCopy);
+
+    // Weighted: matched company appears 3x, others 1x each
+    const verbs = [matchedVerb, matchedVerb, matchedVerb, ...otherVerbs];
+
+    settings.spinnerVerbs = { mode: "replace", verbs };
+    writeFileSync(CLAUDE_SETTINGS, JSON.stringify(settings, null, 2));
+  } catch {
+    // Never break Claude Code over a spinner update
+  }
 }
 
 function summarizeTrigger(hookInput) {


### PR DESCRIPTION
## Summary
- PostToolUse hook rewrites spinnerVerbs in settings.json on each context match
- Matched company gets 3x weight (14% vs 5% for others)
- Claude Code hot-reloads spinner verbs mid-session
- Spinner is now fully contextual — working on auth? See Clerk ads more often
- Bump to v0.4.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)