### PR TITLE
Add CI and tag-triggered npm publish workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,10 +19,11 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 22
-          cache: "npm"
 
+      # package-lock.json is gitignored in this repo, so `npm ci` (which
+      # requires a committed lockfile) is not usable here; install instead.
       - name: Install dependencies
-        run: npm ci
+        run: npm install
 
       - name: Syntax-check bin and src
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,36 @@
+# CI: install, syntax-check every source/bin file, validate the npm package.
+# Runs on every PR and push to main.
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js 22
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Syntax-check bin and src
+        run: |
+          find bin src -name "*.js" -print0 | xargs -0 -n1 node --check
+
+      - name: Validate package (dry-run pack)
+        run: npm pack --dry-run
+
+      - name: Audit
+        run: npm audit --audit-level=moderate
+        continue-on-error: true

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,10 +28,11 @@ jobs:
         with:
           node-version: 22
           registry-url: "https://registry.npmjs.org"
-          cache: "npm"
 
+      # package-lock.json is gitignored in this repo, so `npm ci` (which
+      # requires a committed lockfile) is not usable here; install instead.
       - name: Install dependencies
-        run: npm ci
+        run: npm install
 
       - name: Publish to npm
         run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,45 @@
+# Publish vibeads to npm on a v*.*.* tag push.
+#
+# Usage:
+#   1. Bump "version" in package.json, commit.
+#   2. git tag vX.Y.Z && git push origin vX.Y.Z
+#   3. This workflow builds and publishes automatically.
+#
+# Idempotent: if this exact version is already on the registry, the publish
+# step is skipped rather than failing (safe to rerun / retag).
+#
+# REQUIRED secret (set in repo settings -> Secrets and variables -> Actions):
+#   NPM_TOKEN — npm automation token with publish access to vibeads
+name: Publish
+
+on:
+  push:
+    tags: ["v*.*.*"]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js 22
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          registry-url: "https://registry.npmjs.org"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Publish to npm
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          if npm view "vibeads@$VERSION" version >/dev/null 2>&1; then
+            echo "vibeads@$VERSION already published; skipping."
+          else
+            npm publish --access public
+          fi
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -131,6 +131,18 @@ vibeads is an npm package that installs Claude Code hooks:
 
 All data is stored locally in `~/.vibeads/`. No external API calls. No telemetry.
 
+## Releasing
+
+CI runs on every PR/push to `main` (syntax-check + package validation). To publish
+a new version:
+
+1. Bump `version` in `package.json`, commit, merge to `main`.
+2. `git tag vX.Y.Z && git push origin vX.Y.Z`
+3. The publish workflow builds and publishes to npm automatically (idempotent —
+   safe to rerun; skips if that version is already published).
+
+Requires an `NPM_TOKEN` repo secret (npm automation token with publish access).
+
 ## License
 
 MIT

--- a/src/install.js
+++ b/src/install.js
@@ -109,7 +109,9 @@ export async function init() {
     };
   }
 
-  // Write settings back
+  // Write settings back. ~/.claude/ may not exist yet on a machine that has
+  // never run Claude Code before this install.
+  mkdirSync(dirname(CLAUDE_SETTINGS), { recursive: true });
   writeFileSync(CLAUDE_SETTINGS, JSON.stringify(settings, null, 2));
   console.log("  Added hooks to ~/.claude/settings.json");
   console.log("  Replaced spinner verbs with a16z portfolio ads");


### PR DESCRIPTION
## Summary
No automated gate exists today — versions on npm and local package.json match perfectly, meaning publishing has been manual with nothing validating a build first.

- **CI** (PR/push to main): install, `node --check` every bin/src file, `npm pack --dry-run`, non-blocking audit. No unit test suite exists yet, so this is syntax + packaging validation, not full coverage.
- **Publish** (on `v*.*.*` tag push): builds, publishes, idempotent (skips if the version is already on the registry).
- README gets a short Releasing section.

## Before this works
Add an `NPM_TOKEN` repo secret (npm automation token, publish access) — repo currently has zero secrets configured. Without it the publish job fails cleanly at the auth step (CI itself doesn't need it).

## Test plan
Ran the exact CI steps locally: syntax-check passed on all files, `npm pack --dry-run` produced a clean 12.7kB tarball.