### PR TITLE
Pass backup Claude OAuth token to vibecodereview

### DIFF
--- a/.github/workflows/vibecodereview.yml
+++ b/.github/workflows/vibecodereview.yml
@@ -20,6 +20,7 @@ jobs:
       - uses: pooriaarab/vibecodereview@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          claude_code_oauth_token_2: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN_2 }}
           github_token: ${{ github.token }}
           openai_api_key: ${{ secrets.OPENAI_API_KEY }}
           gemini_api_key: ${{ secrets.GEMINI_API_KEY }}


### PR DESCRIPTION
Adds the claude_code_oauth_token_2 passthrough so the review can fail over to the second subscription. Workflow-only.