### PR TITLE
Cancel superseded CI runs instead of stacking them

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,10 @@ on:
   push:
     branches: [main]
 
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Adds a `concurrency` group to `ci.yml` so that pushing a new commit to a pull request cancels the run still in flight instead of stacking another one beside it.

Found by sweeping all 185 workflow files across the 87 `pooriaarab/*` repos that have any. 126 of them trigger on `pull_request`; these were among the 20 with no concurrency group. The `vibecodereview.yml` files generated from the shared action already set one, so this only affects hand-written workflows.

`cancel-in-progress: true` is safe here because none of these jobs deploy or run migrations — they test, lint and scan. Deploy workflows are deliberately left alone.