### PR TITLE
Make the stack detector data instead of branches

### DIFF
--- a/.github/workflows/oxlint.yml
+++ b/.github/workflows/oxlint.yml
@@ -3,11 +3,17 @@ on:
   pull_request:
   push:
     branches: [main]
+permissions:
+  contents: read
+
 jobs:
   oxlint:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          # bunx runs downloaded package code; keep the token out of .git/config.
+          persist-credentials: false
       - uses: oven-sh/setup-bun@v2
       - name: oxlint (agent budgets — warn-only, ratchet to error later)
         run: bunx oxlint@^1 --config .oxlintrc.json

--- a/src/hooks/session-start.js
+++ b/src/hooks/session-start.js
@@ -86,42 +86,105 @@ function handleSessionStart(hookInput) {
   process.exit(0);
 }
 
+const CONFIG_CHECKS = [
+  { file: "prisma/schema.prisma", tool: "prisma", category: "database" },
+  { file: "drizzle.config.ts", tool: "drizzle", category: "database" },
+  { file: "docker-compose.yml", tool: "docker", category: "infrastructure" },
+  { file: "Dockerfile", tool: "docker", category: "infrastructure" },
+  { file: ".env", tool: "env-vars", category: "config" },
+  { file: "next.config.js", tool: "nextjs", category: "framework" },
+  { file: "next.config.ts", tool: "nextjs", category: "framework" },
+  { file: "vercel.json", tool: "vercel", category: "hosting" },
+  { file: "tailwind.config.js", tool: "tailwind", category: "styling" },
+  { file: "tailwind.config.ts", tool: "tailwind", category: "styling" },
+];
+
+const STACK_DETECTORS = [
+  {
+    id: "supabase",
+    label: "baas",
+    detect: (deps, _files) => deps.some((d) => d.includes("supabase")),
+  },
+  {
+    id: "firebase",
+    label: "baas",
+    detect: (deps, _files) => deps.some((d) => d.includes("firebase")),
+  },
+  {
+    id: "next-auth",
+    label: "auth",
+    detect: (deps, _files) => deps.includes("next-auth") || deps.includes("@auth/core"),
+  },
+  {
+    id: "clerk",
+    label: "auth",
+    detect: (deps, _files) =>
+      deps.includes("@clerk/nextjs") || deps.includes("@clerk/clerk-sdk-node"),
+  },
+  {
+    id: "stripe",
+    label: "payments",
+    detect: (deps, _files) => deps.includes("stripe") || deps.includes("@stripe/stripe-js"),
+  },
+  {
+    id: "raw-sql",
+    label: "database",
+    detect: (deps, _files) => deps.includes("pg") || deps.includes("mysql2"),
+  },
+  {
+    id: "mongodb",
+    label: "database",
+    detect: (deps, _files) => deps.includes("mongoose") || deps.includes("mongodb"),
+  },
+];
+
+const GAP_DETECTORS = [
+  { id: "auth", detect: (_deps, tools) => !tools.auth },
+  { id: "database", detect: (_deps, tools) => !tools.database && !tools.baas },
+  { id: "payments", detect: (_deps, tools) => !tools.payments },
+  {
+    id: "monitoring",
+    detect: (deps) =>
+      !deps.some((d) => d.includes("sentry") || d.includes("datadog")),
+  },
+  {
+    id: "security",
+    detect: (deps) =>
+      !deps.some(
+        (d) =>
+          d.includes("rate-limit") ||
+          d.includes("helmet") ||
+          d.includes("arcjet")
+      ),
+  },
+];
+
+function loadPackageDependencies(cwd) {
+  const pkgPath = join(cwd, "package.json");
+  if (!existsSync(pkgPath)) {
+    return {};
+  }
+  try {
+    const pkg = JSON.parse(readFileSync(pkgPath, "utf-8"));
+    return {
+      ...pkg.dependencies,
+      ...pkg.devDependencies,
+    };
+  } catch {
+    return {};
+  }
+}
+
 function analyzeStack(cwd) {
   const profile = {
     directory: cwd,
-    dependencies: {},
+    dependencies: loadPackageDependencies(cwd),
     configFiles: [],
     detectedTools: {},
     gaps: [],
   };
 
-  const pkgPath = join(cwd, "package.json");
-  if (existsSync(pkgPath)) {
-    try {
-      const pkg = JSON.parse(readFileSync(pkgPath, "utf-8"));
-      profile.dependencies = {
-        ...pkg.dependencies,
-        ...pkg.devDependencies,
-      };
-    } catch {
-      // ignore
-    }
-  }
-
-  const configChecks = [
-    { file: "prisma/schema.prisma", tool: "prisma", category: "database" },
-    { file: "drizzle.config.ts", tool: "drizzle", category: "database" },
-    { file: "docker-compose.yml", tool: "docker", category: "infrastructure" },
-    { file: "Dockerfile", tool: "docker", category: "infrastructure" },
-    { file: ".env", tool: "env-vars", category: "config" },
-    { file: "next.config.js", tool: "nextjs", category: "framework" },
-    { file: "next.config.ts", tool: "nextjs", category: "framework" },
-    { file: "vercel.json", tool: "vercel", category: "hosting" },
-    { file: "tailwind.config.js", tool: "tailwind", category: "styling" },
-    { file: "tailwind.config.ts", tool: "tailwind", category: "styling" },
-  ];
-
-  for (const check of configChecks) {
+  for (const check of CONFIG_CHECKS) {
     if (existsSync(join(cwd, check.file))) {
       profile.configFiles.push(check.file);
       profile.detectedTools[check.category] = check.tool;
@@ -129,94 +192,88 @@ function analyzeStack(cwd) {
   }
 
   const deps = Object.keys(profile.dependencies);
-  if (deps.some((d) => d.includes("supabase")))
-    profile.detectedTools.baas = "supabase";
-  if (deps.some((d) => d.includes("firebase")))
-    profile.detectedTools.baas = "firebase";
-  if (deps.includes("next-auth") || deps.includes("@auth/core"))
-    profile.detectedTools.auth = "next-auth";
-  if (deps.includes("@clerk/nextjs") || deps.includes("@clerk/clerk-sdk-node"))
-    profile.detectedTools.auth = "clerk";
-  if (deps.includes("stripe") || deps.includes("@stripe/stripe-js"))
-    profile.detectedTools.payments = "stripe";
-  if (deps.includes("pg") || deps.includes("mysql2"))
-    profile.detectedTools.database = "raw-sql";
-  if (deps.includes("mongoose") || deps.includes("mongodb"))
-    profile.detectedTools.database = "mongodb";
+  STACK_DETECTORS.reduce((tools, detector) => {
+    if (detector.detect(deps, profile.configFiles)) {
+      tools[detector.label] = detector.id;
+    }
+    return tools;
+  }, profile.detectedTools);
 
-  if (!profile.detectedTools.auth) profile.gaps.push("auth");
-  if (!profile.detectedTools.database && !profile.detectedTools.baas)
-    profile.gaps.push("database");
-  if (!profile.detectedTools.payments) profile.gaps.push("payments");
-  if (!deps.some((d) => d.includes("sentry") || d.includes("datadog")))
-    profile.gaps.push("monitoring");
-  if (
-    !deps.some(
-      (d) =>
-        d.includes("rate-limit") ||
-        d.includes("helmet") ||
-        d.includes("arcjet")
-    )
-  )
-    profile.gaps.push("security");
+  GAP_DETECTORS.reduce((gaps, gap) => {
+    if (gap.detect(deps, profile.detectedTools)) {
+      gaps.push(gap.id);
+    }
+    return gaps;
+  }, profile.gaps);
 
   return profile;
 }
 
-function generateRecommendations(profile) {
-  const recommendations = [];
+const GAP_RECOMMENDATIONS = {
+  auth: {
+    company: { name: "Clerk", slug: "clerk", speedrun: false, website: "https://clerk.com" },
+    type: "missing",
+    message: "No auth detected. Clerk gives you drop-in auth with 10K free MAU",
+  },
+  monitoring: {
+    company: { name: "PagerDuty", slug: "pagerduty", speedrun: false, website: "https://www.pagerduty.com" },
+    type: "missing",
+    message: "No monitoring detected. PagerDuty free tier covers 5 users for incident management",
+  },
+  security: {
+    company: { name: "Arcjet", slug: "arcjet", speedrun: false, website: "https://arcjet.com" },
+    type: "missing",
+    message: "No rate limiting or bot protection. Arcjet adds security middleware in 3 lines",
+  },
+};
 
-  const gapMapping = {
-    auth: {
-      company: { name: "Clerk", slug: "clerk", speedrun: false, website: "https://clerk.com" },
-      type: "missing",
-      message: "No auth detected. Clerk gives you drop-in auth with 10K free MAU",
-    },
-    monitoring: {
-      company: { name: "PagerDuty", slug: "pagerduty", speedrun: false, website: "https://www.pagerduty.com" },
-      type: "missing",
-      message: "No monitoring detected. PagerDuty free tier covers 5 users for incident management",
-    },
-    security: {
-      company: { name: "Arcjet", slug: "arcjet", speedrun: false, website: "https://arcjet.com" },
-      type: "missing",
-      message: "No rate limiting or bot protection. Arcjet adds security middleware in 3 lines",
-    },
-  };
-
-  for (const gap of profile.gaps) {
-    if (gapMapping[gap]) {
-      recommendations.push(gapMapping[gap]);
-    }
-  }
-
-  const deps = Object.keys(profile.dependencies);
-  if (deps.includes("next-auth") || deps.includes("@auth/core")) {
-    recommendations.push({
+const STACK_RECOMMENDATIONS = [
+  {
+    id: "next-auth",
+    detect: (_profile, deps) => deps.includes("next-auth") || deps.includes("@auth/core"),
+    recommendation: {
       company: { name: "Clerk", slug: "clerk", speedrun: false, website: "https://clerk.com" },
       type: "alternative",
       message: "Using next-auth? Clerk replaces 200+ lines of auth config with 5 lines. Free up to 10K MAU",
-    });
-  }
-
-  if (
-    profile.detectedTools.database === "raw-sql" ||
-    deps.includes("prisma") ||
-    deps.includes("drizzle-orm")
-  ) {
-    recommendations.push({
+    },
+  },
+  {
+    id: "planetscale",
+    detect: (profile, deps) =>
+      profile.detectedTools.database === "raw-sql" ||
+      deps.includes("prisma") ||
+      deps.includes("drizzle-orm"),
+    recommendation: {
       company: { name: "PlanetScale", slug: "planetscale", speedrun: false, website: "https://planetscale.com" },
       type: "upgrade",
       message: "PlanetScale: serverless MySQL with non-blocking schema changes. No more migration headaches",
-    });
-  }
-
-  if (deps.some((d) => d.includes("openai"))) {
-    recommendations.push({
+    },
+  },
+  {
+    id: "openai",
+    detect: (_profile, deps) => deps.some((d) => d.includes("openai")),
+    recommendation: {
       company: { name: "Groq", slug: "groq", speedrun: false, website: "https://groq.com" },
       type: "alternative",
       message: "Using OpenAI? Groq runs Llama/Mixtral at 50x the speed. Free tier available",
-    });
+    },
+  },
+];
+
+function generateRecommendations(profile) {
+  const recommendations = [];
+  const deps = Object.keys(profile.dependencies);
+
+  for (const gap of profile.gaps) {
+    if (Object.hasOwn(GAP_RECOMMENDATIONS, gap)) {
+      recommendations.push(GAP_RECOMMENDATIONS[gap]);
+    }
+  }
+
+  for (const rule of STACK_RECOMMENDATIONS) {
+    if (rule.detect(profile, deps)) {
+      recommendations.push(rule.recommendation);
+    }
   }
 
   return recommendations;

--- a/src/install.js
+++ b/src/install.js
@@ -7,29 +7,54 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 const CLAUDE_SETTINGS = join(homedir(), ".claude", "settings.json");
 const VIBEADS_DIR = join(homedir(), ".vibeads");
 
+const FILES_TO_COPY = [
+  { src: "hooks/post-tool.js", dest: "hooks/post-tool.js" },
+  { src: "hooks/session-start.js", dest: "hooks/session-start.js" },
+  { src: "statusline.js", dest: "src/statusline.js" },
+  { src: "matcher/keyword.js", dest: "src/matcher/keyword.js" },
+  { src: "tracker/impressions.js", dest: "src/tracker/impressions.js" },
+  { src: "data/portfolio.json", dest: "src/data/portfolio.json" },
+];
+
 export async function init() {
+  printBanner();
+
+  copyHookFiles();
+  console.log("  Copied hook scripts to ~/.vibeads/");
+
+  const settings = readClaudeSettings();
+  patchClaudeSettings(settings);
+  writeClaudeSettings(settings);
+  console.log("  Added hooks to ~/.claude/settings.json");
+  console.log("  Replaced spinner verbs with a16z portfolio ads");
+
+  writeVibeadsConfig();
+  printSummary();
+}
+
+function printBanner() {
   console.log("");
   console.log("vibeads -- contextual dev tool discovery for Claude Code");
   console.log("Powered by a16z portfolio");
   console.log("");
+}
 
-  // Create vibeads directories
+function printSummary() {
+  console.log("  Loaded 20 a16z portfolio companies");
+  console.log("  Created ~/.vibeads/config.json");
+  console.log("");
+  console.log("Ready! Start a Claude Code session to see recommendations.");
+  console.log("Run 'npx vibeads dashboard' to see your stats.");
+  console.log("");
+}
+
+function copyHookFiles() {
   mkdirSync(join(VIBEADS_DIR, "hooks"), { recursive: true });
   mkdirSync(join(VIBEADS_DIR, "src", "matcher"), { recursive: true });
   mkdirSync(join(VIBEADS_DIR, "src", "tracker"), { recursive: true });
   mkdirSync(join(VIBEADS_DIR, "src", "data"), { recursive: true });
 
-  // Copy source files to ~/.vibeads/ for persistence
-  const filesToCopy = [
-    { src: "hooks/post-tool.js", dest: "hooks/post-tool.js" },
-    { src: "hooks/session-start.js", dest: "hooks/session-start.js" },
-    { src: "statusline.js", dest: "src/statusline.js" },
-    { src: "matcher/keyword.js", dest: "src/matcher/keyword.js" },
-    { src: "tracker/impressions.js", dest: "src/tracker/impressions.js" },
-    { src: "data/portfolio.json", dest: "src/data/portfolio.json" },
-  ];
-
-  for (const file of filesToCopy) {
+  for (const file of FILES_TO_COPY) {
     const srcPath = join(__dirname, file.src);
     const destPath = join(VIBEADS_DIR, file.dest);
     mkdirSync(dirname(destPath), { recursive: true });
@@ -39,24 +64,26 @@ export async function init() {
   chmodSync(join(VIBEADS_DIR, "hooks/post-tool.js"), "755");
   chmodSync(join(VIBEADS_DIR, "hooks/session-start.js"), "755");
   chmodSync(join(VIBEADS_DIR, "src/statusline.js"), "755");
+}
 
-  console.log("  Copied hook scripts to ~/.vibeads/");
-
-  // Read existing Claude settings
-  let settings = {};
-  if (existsSync(CLAUDE_SETTINGS)) {
-    settings = JSON.parse(readFileSync(CLAUDE_SETTINGS, "utf-8"));
+function readClaudeSettings() {
+  if (!existsSync(CLAUDE_SETTINGS)) {
+    return {};
   }
+  return JSON.parse(readFileSync(CLAUDE_SETTINGS, "utf-8"));
+}
 
-  // Add hooks (preserve existing hooks)
+function replaceVibeadsHook(settings, event, entry) {
   if (!settings.hooks) settings.hooks = {};
-
-  // PostToolUse hook
-  if (!settings.hooks.PostToolUse) settings.hooks.PostToolUse = [];
-  settings.hooks.PostToolUse = settings.hooks.PostToolUse.filter(
+  if (!settings.hooks[event]) settings.hooks[event] = [];
+  settings.hooks[event] = settings.hooks[event].filter(
     (h) => !isVibeadsHook(h)
   );
-  settings.hooks.PostToolUse.push({
+  settings.hooks[event].push(entry);
+}
+
+function patchClaudeSettings(settings) {
+  replaceVibeadsHook(settings, "PostToolUse", {
     matcher: "Bash|Write|Edit|Read",
     hooks: [
       {
@@ -67,13 +94,7 @@ export async function init() {
       },
     ],
   });
-
-  // SessionStart hook
-  if (!settings.hooks.SessionStart) settings.hooks.SessionStart = [];
-  settings.hooks.SessionStart = settings.hooks.SessionStart.filter(
-    (h) => !isVibeadsHook(h)
-  );
-  settings.hooks.SessionStart.push({
+  replaceVibeadsHook(settings, "SessionStart", {
     matcher: "startup|resume",
     hooks: [
       {
@@ -84,39 +105,38 @@ export async function init() {
       },
     ],
   });
-
-  // Add status line
   settings.statusLine = {
     type: "command",
     command: `node ${join(VIBEADS_DIR, "src/statusline.js")}`,
   };
+  patchSpinnerVerbs(settings);
+}
 
-  // Replace spinner verbs with ad copy from portfolio
+function patchSpinnerVerbs(settings) {
   const portfolioPath = join(__dirname, "data/portfolio.json");
-  if (existsSync(portfolioPath)) {
-    const portfolio = JSON.parse(readFileSync(portfolioPath, "utf-8"));
-    const adVerbs = portfolio.companies.map((c) => c.spinnerCopy);
-    // Save original spinnerVerbs so we can restore on uninstall
-    if (settings.spinnerVerbs) {
-      writeFileSync(
-        join(VIBEADS_DIR, "original-spinner-verbs.json"),
-        JSON.stringify(settings.spinnerVerbs)
-      );
-    }
-    settings.spinnerVerbs = {
-      mode: "replace",
-      verbs: adVerbs,
-    };
+  if (!existsSync(portfolioPath)) {
+    return;
   }
+  const portfolio = JSON.parse(readFileSync(portfolioPath, "utf-8"));
+  const adVerbs = portfolio.companies.map((c) => c.spinnerCopy);
+  if (settings.spinnerVerbs) {
+    writeFileSync(
+      join(VIBEADS_DIR, "original-spinner-verbs.json"),
+      JSON.stringify(settings.spinnerVerbs)
+    );
+  }
+  settings.spinnerVerbs = {
+    mode: "replace",
+    verbs: adVerbs,
+  };
+}
 
-  // Write settings back. ~/.claude/ may not exist yet on a machine that has
-  // never run Claude Code before this install.
+function writeClaudeSettings(settings) {
   mkdirSync(dirname(CLAUDE_SETTINGS), { recursive: true });
   writeFileSync(CLAUDE_SETTINGS, JSON.stringify(settings, null, 2));
-  console.log("  Added hooks to ~/.claude/settings.json");
-  console.log("  Replaced spinner verbs with a16z portfolio ads");
+}
 
-  // Create initial config
+function writeVibeadsConfig() {
   const config = {
     version: "0.1.0",
     installed: new Date().toISOString(),
@@ -131,20 +151,12 @@ export async function init() {
   };
   writeFileSync(join(VIBEADS_DIR, "config.json"), JSON.stringify(config, null, 2));
 
-  // Initialize empty impressions
   if (!existsSync(join(VIBEADS_DIR, "impressions.json"))) {
     writeFileSync(
       join(VIBEADS_DIR, "impressions.json"),
       JSON.stringify({ impressions: [], stats: {} }, null, 2)
     );
   }
-
-  console.log("  Loaded 20 a16z portfolio companies");
-  console.log("  Created ~/.vibeads/config.json");
-  console.log("");
-  console.log("Ready! Start a Claude Code session to see recommendations.");
-  console.log("Run 'npx vibeads dashboard' to see your stats.");
-  console.log("");
 }
 
 function isVibeadsHook(hookGroup) {


### PR DESCRIPTION
First of two burndown PRs for this repo. This one covers `src/` and `bin/`; `video/VibeadsDemo.tsx` follows separately so each diff stays reviewable.

**Before (in `src/` + `bin/`):** `analyzeStack` complexity 23 / 69 lines, `generateRecommendations` 52 lines, `init` 111 lines. **After:** 0 violations outside `video/`.

### `analyzeStack` — complexity 23

It was one long list of independent checks: one `if` per recognised dependency, one per config file, one per gap. Adding a stack meant editing a function already over budget.

Now each list is a table — `CONFIG_CHECKS`, `STACK_DETECTORS`, `GAP_DETECTORS` — and `analyzeStack` folds over them. `generateRecommendations` gets the same treatment via `GAP_RECOMMENDATIONS` / `STACK_RECOMMENDATIONS`. Adding a detector is now one array entry.

`install.js` `init` splits into one helper per installation phase, console output untouched.

### Verification

No test suite here, so I ran the real code both ways and diffed:

- **session-start hook** over 12 fixture projects — every detector, plus a project with no `package.json` and one with unparseable JSON. Compared stdout *and* every file written under a temporary `HOME`. **13 KB of output, identical.**
- **`vibeads init`** — same stdout, same 9 files, same JSON, differing only in the temp `HOME` path.

### Rules stay at `warn`

`complexity`, `max-lines-per-function` and `max-lines` are **not** promoted yet — `video/VibeadsDemo.tsx` still violates all three. The promotion lands with that PR.

Also hardens the oxlint workflow (`permissions: contents: read`, `persist-credentials: false`), matching the rest of the fleet.