### PR TITLE
Gate run cancellation on pull_request events

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,9 +8,11 @@ on:
   push:
     branches: [main]
 
+# Cancel a superseded PR run, but never a push to the default branch —
+# that run is the record of what landed on main.
 concurrency:
-  group: ci-${{ github.ref }}
-  cancel-in-progress: true
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   test:

--- a/.github/workflows/oxlint.yml
+++ b/.github/workflows/oxlint.yml
@@ -6,6 +6,12 @@ on:
 permissions:
   contents: read
 
+# Cancel a superseded PR run, but never a push to the default branch —
+# that run is the record of what landed on main.
+concurrency:
+  group: oxlint-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   oxlint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## What

Add a `concurrency` group to `.github/workflows/oxlint.yml`, which had
none, and gate `cancel-in-progress` on `pull_request` in both
`oxlint.yml` and `ci.yml`.

```yaml
concurrency:
  group: <name>-${{ github.workflow }}-${{ github.ref }}
  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
```

## Why

Two separate problems.

**1. `oxlint.yml` had no concurrency group.** PR #13 (merged
2026-08-26) added one to `ci.yml` and `gitleaks.yml`. PR #14 (merged
2026-08-27, commit 285f9d5) introduced `oxlint.yml` from scratch a day
later and never carried the pattern forward, so every superseded push
or PR update left its stale oxlint run going to completion.

**2. The existing pattern it would have mirrored is itself wrong.**
Both `oxlint.yml` and `ci.yml` trigger on `pull_request` *and*
`push: branches: [main]`. An unconditional `cancel-in-progress: true`
therefore cancels superseded pushes to the default branch, not only PR
updates. A default-branch run is the record of what landed on that
branch — cancelling it leaves that commit with no result, and in a repo
where such a run seeds a cache it loses the save too. So this gates the
cancellation on `pull_request` instead of copying the unconditional
form, and applies the same correction to `ci.yml`.

`${{ github.workflow }}` is included in the group key so two workflows
sharing a ref cannot cancel each other.

## Deliberately not changed

- **`gitleaks.yml`** carries the same unconditional shape and is *not*
  touched here — it is covered by a separate fleet-wide change. It is
  the most harmful instance of this shape: gitleaks runs a full-history
  scan with `fetch-depth: 0`, so cancelling a push-triggered run means
  a commit never gets secret-scanned and nothing reports the gap.
- No `actions/cache` exists anywhere in this repo's workflows
  (`grep -rn "cache" .github/workflows/` → no hits), so the cache-key,
  `restore-keys`, and build-output-glob items don't apply.
- The CI job's steps (install, syntax-check, pack, audit) each complete
  in 0-2s across 10 recent runs; not worth splitting into parallel
  jobs, and the `continue-on-error` audit step isn't the long pole.
- All `branches:` filters correctly reference `main`, the repo's actual
  default branch.
