### PR TITLE
Gate gitleaks cancel-in-progress on pull_request

### DIFF
--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -9,9 +9,11 @@ permissions:
   contents: read
   pull-requests: read
 
+# Cancel a superseded PR run, but never a push to the default branch — since
+# gitleaks scans full history, a cancelled push leaves a commit unscanned.
 concurrency:
-  group: secret-scanning-${{ github.ref }}
-  cancel-in-progress: true
+  group: secret-scanning-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   gitleaks:


### PR DESCRIPTION
## What

`concurrency.cancel-in-progress` in `gitleaks.yml` was unconditionally
`true`. Every push to the default branch shares one `github.ref`, so a
second push landing while the first scan was still running cancelled
it outright.

## Why it matters

gitleaks scans full commit history (`fetch-depth: 0`). A cancelled
push-triggered run leaves that commit unscanned — silently. Nothing
fails, nothing warns; the run just shows `cancelled` in a list nobody
reads.

## Fix

- Gate the cancellation on `pull_request`. A superseded PR run is
  still safe to cancel — the next push re-scans the same head. A push
  to the default branch now always runs to completion.
- Add `github.workflow` to the concurrency group so gitleaks and any
  other workflow sharing the same ref can't cancel each other.

Same shape already landed in this repo's `oxlint.yml`.