### PR TITLE
[VA-25] Adopt oxfmt as the formatter (part 2/2)

### DIFF
--- a/.github/workflows/oxfmt.yml
+++ b/.github/workflows/oxfmt.yml
@@ -1,0 +1,28 @@
+name: oxfmt
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  format:
+    name: oxfmt --check
+    runs-on: ubicloud-standard-2
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - uses: oven-sh/setup-bun@v2
+
+      - name: Check formatting
+        run: bunx oxfmt@0.65 --check .

--- a/.oxfmtrc.json
+++ b/.oxfmtrc.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "https://unpkg.com/oxfmt@0.65.0/configuration_schema.json",
+  "ignorePatterns": [
+    "**/vendor/**",
+    "**/third_party/**",
+    "**/generated/**",
+    "**/*.generated.*",
+    "**/*.min.js",
+    "**/*.min.css",
+    "**/*.bundle.js",
+    "**/dist/**",
+    "**/build/**",
+    "**/.next/**",
+    "**/.wrangler/**",
+    "**/.open-next/**",
+    "**/coverage/**"
+  ]
+}

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -1,11 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/oxc-project/oxc/main/npm/oxlint/configuration_schema.json",
-  "plugins": [
-    "typescript",
-    "import",
-    "unicorn",
-    "oxc"
-  ],
+  "plugins": ["typescript", "import", "unicorn", "oxc"],
   "categories": {
     "correctness": "warn",
     "suspicious": "warn",
@@ -84,11 +79,7 @@
       }
     },
     {
-      "files": [
-        "scripts/**",
-        "**/scripts/**",
-        "**/*.config.*"
-      ],
+      "files": ["scripts/**", "**/scripts/**", "**/*.config.*"],
       "rules": {
         "max-lines-per-function": "off",
         "complexity": "off"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,7 @@
 # AGENTS.md
 
 <!-- pr-standards:start -->
+
 ## Pull requests
 
 One issue. One PR. One concern. Under 500 counted lines.

--- a/SKILL.md
+++ b/SKILL.md
@@ -10,6 +10,7 @@ Contextual dev tool discovery for Claude Code. While Claude Code works, vibeads 
 ## When to Use This Skill
 
 Use this skill when the user:
+
 - Wants to discover relevant developer tools while coding
 - Asks about alternatives to their current tech stack
 - Wants contextual tool recommendations based on their project

--- a/docs/plans/2026-02-18-vibeads-design.md
+++ b/docs/plans/2026-02-18-vibeads-design.md
@@ -21,6 +21,7 @@ Developers install vibeads. While Claude Code works, instead of staring at gener
 ## Target User
 
 Developers using Claude Code who want to:
+
 1. Discover better tools for their stack
 2. Earn free credits from developer tool companies
 3. Get contextual, genuinely useful recommendations (not spam)
@@ -45,6 +46,7 @@ Free tier available. planetscale.com/vibeads
 During `PostToolUse` hook execution, we show persuasive, data-driven messages via the `statusMessage` field. No emojis. Sharp copy with specific comparative data.
 
 Examples:
+
 ```
 Supabase cold start: ~2s. PlanetScale: 0ms. Upgrade your stack.
 next-auth setup: 200 lines. Clerk: 5 lines. See why founders switch.
@@ -66,6 +68,7 @@ A `prompt`-type hook makes a single LLM call (using the user's own Claude subscr
 An `agent`-type hook analyzes the full context and injects a `systemMessage` so Claude itself can mention tool recommendations naturally in its response.
 
 Example Claude output:
+
 > "I've set up your Prisma schema. By the way, if you're looking for a hosted database, PlanetScale (backed by a16z) offers a generous free tier for indie developers."
 
 **Matching intelligence:** Agent-type hook (full analysis, most contextual).
@@ -75,6 +78,7 @@ Example Claude output:
 On `SessionStart`, scan the user's `package.json`, config files, and imports to build a tech stack profile. Then recommend a16z alternatives with specific, comparative data highlighting drawbacks of current tools.
 
 Example stack profile:
+
 ```json
 {
   "database": "supabase",
@@ -86,6 +90,7 @@ Example stack profile:
 ```
 
 Recommendations highlight concrete differences:
+
 - "Your Supabase queries average 200ms. PlanetScale (a16z): <10ms at edge."
 - "No monitoring detected. Datadog (a16z) free tier: 5 hosts, 1-day retention."
 
@@ -102,16 +107,16 @@ Recommendations highlight concrete differences:
 
 Real a16z portfolio companies mapped to developer contexts:
 
-| Context Signal | Keywords | a16z Company | One-liner |
-|---|---|---|---|
-| Database | prisma, postgres, mysql, sqlite, drizzle, pg | PlanetScale | Serverless MySQL, scales to zero |
-| Auth | auth, jwt, oauth, session, login, signup | Clerk | Drop-in auth in 5 minutes |
-| AI/ML | openai, llm, embeddings, vector, huggingface | Replicate | Run ML models with one API call |
-| Infrastructure | docker, k8s, deploy, hosting, server | Render | Deploy anything, zero config |
-| Payments | stripe, payment, billing, checkout, subscription | Stripe | Payments infrastructure for devs |
-| Frontend | react, next, tailwind, vercel, ui components | Vercel | Ship frontend faster |
-| Monitoring | error, logging, sentry, crash, metrics | Datadog | See everything in your stack |
-| Mobile | react-native, expo, ios, android, mobile | Rork | AI-native mobile app builder |
+| Context Signal | Keywords                                         | a16z Company | One-liner                        |
+| -------------- | ------------------------------------------------ | ------------ | -------------------------------- |
+| Database       | prisma, postgres, mysql, sqlite, drizzle, pg     | PlanetScale  | Serverless MySQL, scales to zero |
+| Auth           | auth, jwt, oauth, session, login, signup         | Clerk        | Drop-in auth in 5 minutes        |
+| AI/ML          | openai, llm, embeddings, vector, huggingface     | Replicate    | Run ML models with one API call  |
+| Infrastructure | docker, k8s, deploy, hosting, server             | Render       | Deploy anything, zero config     |
+| Payments       | stripe, payment, billing, checkout, subscription | Stripe       | Payments infrastructure for devs |
+| Frontend       | react, next, tailwind, vercel, ui components     | Vercel       | Ship frontend faster             |
+| Monitoring     | error, logging, sentry, crash, metrics           | Datadog      | See everything in your stack     |
+| Mobile         | react-native, expo, ios, android, mobile         | Rork         | AI-native mobile app builder     |
 
 Full portfolio mapping will include ~20-30 companies with accurate a16z investment data.
 
@@ -143,6 +148,7 @@ vibeads/
 ## User Experience Flow
 
 ### Installation
+
 ```
 $ npx vibeads init
 
@@ -163,6 +169,7 @@ Run 'npx vibeads dashboard' to see your stats.
 Status line shows contextual recommendation. Spinner verbs show persuasive copy during tool execution. Claude occasionally mentions relevant tools in responses.
 
 ### Dashboard
+
 ```
 $ npx vibeads dashboard
 
@@ -177,6 +184,7 @@ Stack analysis:        Last run 2h ago
 ```
 
 ### Uninstall
+
 ```
 $ npx vibeads uninstall
 
@@ -233,6 +241,7 @@ The installer adds entries to `~/.claude/settings.json`:
 ### Data Storage
 
 All local data stored in `~/.vibeads/`:
+
 - `config.json` — user preferences, placement tiers enabled
 - `impressions.json` — local impression/click tracking
 - `stack-profile.json` — cached tech stack analysis

--- a/docs/plans/2026-02-19-demo-video-design.md
+++ b/docs/plans/2026-02-19-demo-video-design.md
@@ -16,16 +16,19 @@
 ## Storyboard (8 Scenes)
 
 ### Scene 1: THE HOOK (0s-3s)
+
 - Black screen, blinking cursor, types: `> claude "build me an app"`
 - Audio: Low synth drone fading in. No voice.
 
 ### Scene 2: THE WAIT (3s-7s)
+
 - Realistic Claude Code terminal with generic spinner ("Thinking...")
 - Slow zoom on the spinner area, dim glow highlight
 - VO: "Three million developers vibecode every day. And while they wait..."
 - Audio: Drone builds, bass pulse on "wait"
 
 ### Scene 3: THE DEAD SPACE (7s-10s)
+
 - Quick cuts: 3 rapid shots of dead moments (spinner, empty status bar, blank session start)
 - Each highlighted with pulsing red/orange box
 - Large center text: `DEAD TIME`
@@ -33,6 +36,7 @@
 - Audio: Bass drop, beat of silence
 
 ### Scene 4: THE REVEAL (10s-14s)
+
 - Same terminal, now with vibeads. Zoom on spinner: "Add auth in 5 lines with Clerk..."
 - Pull back to show status line with Clerk recommendation
 - Both glow cyan
@@ -40,6 +44,7 @@
 - Audio: Synth chord resolves upward
 
 ### Scene 5: THE PLACEMENTS (14s-20s)
+
 - Rapid montage, ~1.5s per placement with label overlay:
   1. SPINNER VERBS - PlanetScale ad in spinner
   2. STATUS LINE - Groq ad with clickable link
@@ -49,6 +54,7 @@
 - VO: "Contextual. Native. Five placement tiers, woven into the workflow."
 
 ### Scene 6: THE SCALE (20s-24s)
+
 - Dark background. Visual metaphors:
   - Grid of tiny circles filling screen (3M developers)
   - 20 colored dots arranged in a cluster (portfolio companies)
@@ -57,12 +63,14 @@
 - VO: "Twenty portfolio companies. Zero friction. One npm install."
 
 ### Scene 7: THE INSTALL (24s-27s)
+
 - Clean terminal. Types: `npm install -g vibeads`
 - Output appears: "vibeads - contextual dev tool discovery... Ready!"
 - No voiceover. Terminal speaks.
 - Audio: Clean satisfying tone
 
 ### Scene 8: THE CLOSE (27s-30s)
+
 - Black screen. "vibeads" fades in center
 - Subtitle: "ads for the age of vibecoding"
 - Small: github.com/pooriaarab/vibeads

--- a/package.json
+++ b/package.json
@@ -2,7 +2,20 @@
   "name": "vibeads",
   "version": "0.4.0",
   "description": "Contextual dev tool discovery for Claude Code — powered by a16z portfolio",
-  "type": "module",
+  "keywords": [
+    "a16z",
+    "ads",
+    "claude-code",
+    "developer-tools",
+    "hooks",
+    "vibeads"
+  ],
+  "license": "MIT",
+  "author": "Pooria Arab",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/pooriaarab/vibeads.git"
+  },
   "bin": {
     "vibeads": "bin/vibeads.js"
   },
@@ -11,21 +24,8 @@
     "src/",
     "README.md"
   ],
-  "keywords": [
-    "claude-code",
-    "developer-tools",
-    "a16z",
-    "vibeads",
-    "ads",
-    "hooks"
-  ],
-  "author": "Pooria Arab",
-  "license": "MIT",
+  "type": "module",
   "scripts": {
     "postinstall": "node bin/vibeads.js init"
-  },
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/pooriaarab/vibeads.git"
   }
 }

--- a/src/dashboard.js
+++ b/src/dashboard.js
@@ -45,9 +45,7 @@ export async function dashboard() {
     }
   }
 
-  const config = JSON.parse(
-    readFileSync(join(VIBEADS_DIR, "config.json"), "utf-8")
-  );
+  const config = JSON.parse(readFileSync(join(VIBEADS_DIR, "config.json"), "utf-8"));
   const activeTiers = Object.entries(config.tiers)
     .filter(([, v]) => v)
     .map(([k]) => k);

--- a/src/hooks/post-tool.js
+++ b/src/hooks/post-tool.js
@@ -46,13 +46,13 @@ function handlePostToolUse(hookInput) {
       company: match,
       trigger: `${hookInput.tool_name}: ${summarizeTrigger(hookInput)}`,
       timestamp: new Date().toISOString(),
-    })
+    }),
   );
 
   recordImpression(
     match.slug,
     "post-tool",
-    `${hookInput.tool_name}: ${summarizeTrigger(hookInput)}`
+    `${hookInput.tool_name}: ${summarizeTrigger(hookInput)}`,
   );
 
   // Update spinner verb to match the current context

--- a/src/install.js
+++ b/src/install.js
@@ -76,9 +76,7 @@ function readClaudeSettings() {
 function replaceVibeadsHook(settings, event, entry) {
   if (!settings.hooks) settings.hooks = {};
   if (!settings.hooks[event]) settings.hooks[event] = [];
-  settings.hooks[event] = settings.hooks[event].filter(
-    (h) => !isVibeadsHook(h)
-  );
+  settings.hooks[event] = settings.hooks[event].filter((h) => !isVibeadsHook(h));
   settings.hooks[event].push(entry);
 }
 
@@ -122,7 +120,7 @@ function patchSpinnerVerbs(settings) {
   if (settings.spinnerVerbs) {
     writeFileSync(
       join(VIBEADS_DIR, "original-spinner-verbs.json"),
-      JSON.stringify(settings.spinnerVerbs)
+      JSON.stringify(settings.spinnerVerbs),
     );
   }
   settings.spinnerVerbs = {
@@ -154,13 +152,11 @@ function writeVibeadsConfig() {
   if (!existsSync(join(VIBEADS_DIR, "impressions.json"))) {
     writeFileSync(
       join(VIBEADS_DIR, "impressions.json"),
-      JSON.stringify({ impressions: [], stats: {} }, null, 2)
+      JSON.stringify({ impressions: [], stats: {} }, null, 2),
     );
   }
 }
 
 function isVibeadsHook(hookGroup) {
-  return hookGroup.hooks?.some((h) =>
-    h.command?.includes(".vibeads")
-  );
+  return hookGroup.hooks?.some((h) => h.command?.includes(".vibeads"));
 }

--- a/src/matcher/keyword.js
+++ b/src/matcher/keyword.js
@@ -3,9 +3,7 @@ import { dirname, join } from "path";
 import { fileURLToPath } from "url";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
-const portfolio = JSON.parse(
-  readFileSync(join(__dirname, "../data/portfolio.json"), "utf-8")
-);
+const portfolio = JSON.parse(readFileSync(join(__dirname, "../data/portfolio.json"), "utf-8"));
 
 export function matchKeyword(context) {
   const text = extractSearchableText(context).toLowerCase();
@@ -41,8 +39,7 @@ function extractSearchableText(context) {
     } else {
       if (context.toolInput.command) parts.push(context.toolInput.command);
       if (context.toolInput.file_path) parts.push(context.toolInput.file_path);
-      if (context.toolInput.content)
-        parts.push(context.toolInput.content.slice(0, 500));
+      if (context.toolInput.content) parts.push(context.toolInput.content.slice(0, 500));
       if (context.toolInput.pattern) parts.push(context.toolInput.pattern);
       if (context.toolInput.query) parts.push(context.toolInput.query);
     }

--- a/src/statusline.js
+++ b/src/statusline.js
@@ -45,10 +45,8 @@ function render() {
   const url = company.website + "?ref=vibeads";
 
   console.log(
-    `\x1b[36m${company.name}\x1b[0m\x1b[90m${speedrunBadge} (a16z)\x1b[0m -- ${company.oneLiner}`
+    `\x1b[36m${company.name}\x1b[0m\x1b[90m${speedrunBadge} (a16z)\x1b[0m -- ${company.oneLiner}`,
   );
 
-  console.log(
-    `\x1b[90m  \x1b]8;;${url}\x07${url}\x1b]8;;\x07\x1b[0m`
-  );
+  console.log(`\x1b[90m  \x1b]8;;${url}\x07${url}\x1b]8;;\x07\x1b[0m`);
 }

--- a/src/tracker/impressions.js
+++ b/src/tracker/impressions.js
@@ -38,8 +38,7 @@ export function recordImpression(companySlug, tier, context) {
     data.stats[companySlug] = { total: 0, byTier: {}, firstSeen: impression.timestamp };
   }
   data.stats[companySlug].total++;
-  data.stats[companySlug].byTier[tier] =
-    (data.stats[companySlug].byTier[tier] || 0) + 1;
+  data.stats[companySlug].byTier[tier] = (data.stats[companySlug].byTier[tier] || 0) + 1;
   data.stats[companySlug].lastSeen = impression.timestamp;
 
   saveImpressions(data);
@@ -49,9 +48,7 @@ export function getStats() {
   const data = loadImpressions();
   const today = new Date().toISOString().slice(0, 10);
 
-  const todayImpressions = data.impressions.filter((i) =>
-    i.timestamp.startsWith(today)
-  );
+  const todayImpressions = data.impressions.filter((i) => i.timestamp.startsWith(today));
 
   const uniqueCompanies = new Set(data.impressions.map((i) => i.company));
 

--- a/src/uninstall.js
+++ b/src/uninstall.js
@@ -14,7 +14,7 @@ export async function uninstall() {
     if (settings.hooks) {
       for (const event of Object.keys(settings.hooks)) {
         settings.hooks[event] = settings.hooks[event].filter(
-          (h) => !h.hooks?.some((hook) => hook.command?.includes(".vibeads"))
+          (h) => !h.hooks?.some((hook) => hook.command?.includes(".vibeads")),
         );
         if (settings.hooks[event].length === 0) {
           delete settings.hooks[event];

--- a/test/next.config.js
+++ b/test/next.config.js
@@ -1,6 +1,6 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
-}
+};
 
-module.exports = nextConfig
+module.exports = nextConfig;

--- a/test/package.json
+++ b/test/package.json
@@ -2,12 +2,12 @@
   "name": "demo-saas-app",
   "version": "1.0.0",
   "dependencies": {
-    "next": "^14.0.0",
-    "react": "^18.0.0",
-    "next-auth": "^4.24.0",
-    "prisma": "^5.0.0",
     "@prisma/client": "^5.0.0",
+    "next": "^14.0.0",
+    "next-auth": "^4.24.0",
     "openai": "^4.0.0",
+    "prisma": "^5.0.0",
+    "react": "^18.0.0",
     "tailwindcss": "^3.4.0"
   },
   "devDependencies": {

--- a/test/tailwind.config.js
+++ b/test/tailwind.config.js
@@ -3,4 +3,4 @@ module.exports = {
   content: ["./src/**/*.{js,ts,jsx,tsx}"],
   theme: { extend: {} },
   plugins: [],
-}
+};

--- a/video/package.json
+++ b/video/package.json
@@ -9,8 +9,8 @@
     "preview": "remotion preview"
   },
   "dependencies": {
-    "@remotion/cli": "4.0.421",
     "@remotion/bundler": "4.0.421",
+    "@remotion/cli": "4.0.421",
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "remotion": "4.0.421"

--- a/video/src/VibeadsDemo.tsx
+++ b/video/src/VibeadsDemo.tsx
@@ -1,11 +1,5 @@
 import React from "react";
-import {
-  AbsoluteFill,
-  Audio,
-  Sequence,
-  staticFile,
-  useCurrentFrame,
-} from "remotion";
+import { AbsoluteFill, Audio, Sequence, staticFile, useCurrentFrame } from "remotion";
 import { SceneClose } from "./scenes/SceneClose";
 import { SceneDeadSpace } from "./scenes/SceneDeadSpace";
 import { SceneHook } from "./scenes/SceneHook";

--- a/video/src/components/DotGrid.tsx
+++ b/video/src/components/DotGrid.tsx
@@ -43,24 +43,17 @@ export const DotGrid: React.FC<{
   const cols = Math.ceil(Math.sqrt(count * 2));
   const rows = Math.ceil(count / cols);
   const visibleDots = Math.min(
-    Math.floor(interpolate(elapsed, [0, 40], [0, count], {
-      extrapolateRight: "clamp",
-    })),
-    count
+    Math.floor(
+      interpolate(elapsed, [0, 40], [0, count], {
+        extrapolateRight: "clamp",
+      }),
+    ),
+    count,
   );
 
   const dots: React.ReactNode[] = [];
   for (let i = 0; i < visibleDots; i++) {
-    dots.push(
-      <GridDot
-        key={i}
-        i={i}
-        cols={cols}
-        elapsed={elapsed}
-        count={count}
-        color={color}
-      />
-    );
+    dots.push(<GridDot key={i} i={i} cols={cols} elapsed={elapsed} count={count} color={color} />);
   }
 
   return (

--- a/video/src/components/Spinner.tsx
+++ b/video/src/components/Spinner.tsx
@@ -16,9 +16,7 @@ export const Spinner: React.FC<{
         display: "flex",
         alignItems: "center",
         gap: 12,
-        textShadow: glowing
-          ? `0 0 15px ${color}60, 0 0 30px ${color}30`
-          : "none",
+        textShadow: glowing ? `0 0 15px ${color}60, 0 0 30px ${color}30` : "none",
       }}
     >
       <span style={{ color, fontSize: 24 }}>{spinChars[idx]}</span>

--- a/video/src/components/Terminal.tsx
+++ b/video/src/components/Terminal.tsx
@@ -55,9 +55,7 @@ const TerminalStatusLine: React.FC<{
         fontFamily: "'SF Mono', 'Fira Code', monospace",
         fontSize: 14,
         color: statusLineGlow ? CYAN : GRAY,
-        textShadow: statusLineGlow
-          ? `0 0 10px ${CYAN}40, 0 0 20px ${CYAN}20`
-          : "none",
+        textShadow: statusLineGlow ? `0 0 10px ${CYAN}40, 0 0 20px ${CYAN}20` : "none",
         transition: "all 0.3s",
       }}
     >
@@ -66,9 +64,7 @@ const TerminalStatusLine: React.FC<{
   );
 };
 
-const TerminalBody: React.FC<{ children: React.ReactNode }> = ({
-  children,
-}) => {
+const TerminalBody: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   return (
     <div
       style={{
@@ -93,13 +89,7 @@ export const Terminal: React.FC<{
   statusLine?: string;
   showStatusLine?: boolean;
   statusLineGlow?: boolean;
-}> = ({
-  children,
-  scale = 1,
-  statusLine,
-  showStatusLine = false,
-  statusLineGlow = false,
-}) => {
+}> = ({ children, scale = 1, statusLine, showStatusLine = false, statusLineGlow = false }) => {
   return (
     <div
       style={{
@@ -115,10 +105,7 @@ export const Terminal: React.FC<{
       <TerminalTitleBar />
       <TerminalBody>{children}</TerminalBody>
       {showStatusLine && (
-        <TerminalStatusLine
-          statusLine={statusLine}
-          statusLineGlow={statusLineGlow}
-        />
+        <TerminalStatusLine statusLine={statusLine} statusLineGlow={statusLineGlow} />
       )}
     </div>
   );

--- a/video/src/components/TypingText.tsx
+++ b/video/src/components/TypingText.tsx
@@ -58,11 +58,7 @@ export const TypingText: React.FC<{
       }}
     >
       {displayText}
-      <TypingCursor
-        showCursor={showCursor}
-        isDone={isDone}
-        cursorVisible={cursorVisible}
-      />
+      <TypingCursor showCursor={showCursor} isDone={isDone} cursorVisible={cursorVisible} />
     </span>
   );
 };

--- a/video/src/scenes/SceneInstall.tsx
+++ b/video/src/scenes/SceneInstall.tsx
@@ -20,8 +20,7 @@ const InstallResults: React.FC<{
           fontSize: 20,
         }}
       >
-        vibeads {"\u2014"} contextual dev tool discovery for
-        Claude Code
+        vibeads {"\u2014"} contextual dev tool discovery for Claude Code
       </div>
       <div
         style={{
@@ -53,13 +52,7 @@ const InstallTerminal: React.FC<{
   line2Opacity: number;
   line3Opacity: number;
   line4Opacity: number;
-}> = ({
-  localFrame,
-  line1Done,
-  line2Opacity,
-  line3Opacity,
-  line4Opacity,
-}) => {
+}> = ({ localFrame, line1Done, line2Opacity, line3Opacity, line4Opacity }) => {
   return (
     <Terminal scale={1}>
       <div>

--- a/video/src/scenes/ScenePlacements.tsx
+++ b/video/src/scenes/ScenePlacements.tsx
@@ -11,38 +11,20 @@ const PlacementContent: React.FC<{
   placementDuration: number;
 }> = ({ localFrame, placementDuration }) => {
   if (localFrame < placementDuration) {
-    return (
-      <PlacementSpinnerVerbs
-        localFrame={localFrame}
-        placementDuration={placementDuration}
-      />
-    );
+    return <PlacementSpinnerVerbs localFrame={localFrame} placementDuration={placementDuration} />;
   }
 
   if (localFrame < placementDuration * 2) {
-    return (
-      <PlacementStatusLine
-        localFrame={localFrame}
-        placementDuration={placementDuration}
-      />
-    );
+    return <PlacementStatusLine localFrame={localFrame} placementDuration={placementDuration} />;
   }
 
   if (localFrame < placementDuration * 3) {
     return (
-      <PlacementContextInjection
-        localFrame={localFrame}
-        placementDuration={placementDuration}
-      />
+      <PlacementContextInjection localFrame={localFrame} placementDuration={placementDuration} />
     );
   }
 
-  return (
-    <PlacementStackAnalysis
-      localFrame={localFrame}
-      placementDuration={placementDuration}
-    />
-  );
+  return <PlacementStackAnalysis localFrame={localFrame} placementDuration={placementDuration} />;
 };
 
 export const ScenePlacements: React.FC<{ frame: number }> = ({ frame }) => {
@@ -58,10 +40,7 @@ export const ScenePlacements: React.FC<{ frame: number }> = ({ frame }) => {
         justifyContent: "center",
       }}
     >
-      <PlacementContent
-        localFrame={localFrame}
-        placementDuration={placementDuration}
-      />
+      <PlacementContent localFrame={localFrame} placementDuration={placementDuration} />
     </AbsoluteFill>
   );
 };

--- a/video/src/scenes/SceneReveal.tsx
+++ b/video/src/scenes/SceneReveal.tsx
@@ -28,9 +28,7 @@ const RevealTerminal: React.FC<{
         <span style={{ color: WHITE }}>build me an app</span>
       </div>
       <div style={{ height: 20 }} />
-      <div style={{ color: DIM, fontSize: 18, marginBottom: 16 }}>
-        Claude is working...
-      </div>
+      <div style={{ color: DIM, fontSize: 18, marginBottom: 16 }}>Claude is working...</div>
       <div style={{ opacity: spinnerReveal }}>
         <HighlightBox color={CYAN} frame={localFrame}>
           <Spinner

--- a/video/src/scenes/SceneScale.tsx
+++ b/video/src/scenes/SceneScale.tsx
@@ -26,26 +26,10 @@ export const SceneScale: React.FC<{ frame: number }> = ({ frame }) => {
       }}
     >
       <AbsoluteFill>
-        <ScaleDevelopers
-          localFrame={localFrame}
-          left={col1X}
-          top={row1Y}
-        />
-        <ScalePortfolio
-          localFrame={localFrame}
-          left={col2X}
-          top={row1Y}
-        />
-        <ScaleLayers
-          localFrame={localFrame}
-          left={col1X}
-          top={row2Y}
-        />
-        <ScaleZeroLines
-          localFrame={localFrame}
-          left={col2X}
-          top={row2Y}
-        />
+        <ScaleDevelopers localFrame={localFrame} left={col1X} top={row1Y} />
+        <ScalePortfolio localFrame={localFrame} left={col2X} top={row1Y} />
+        <ScaleLayers localFrame={localFrame} left={col1X} top={row2Y} />
+        <ScaleZeroLines localFrame={localFrame} left={col2X} top={row2Y} />
       </AbsoluteFill>
     </AbsoluteFill>
   );

--- a/video/src/scenes/SceneWait.tsx
+++ b/video/src/scenes/SceneWait.tsx
@@ -12,22 +12,12 @@ const WaitHighlight: React.FC<{
 }> = ({ localFrame, currentSpinner }) => {
   return (
     <HighlightBox
-      color={`${ORANGE}${Math.floor(
-        interpolate(
-          Math.sin(localFrame * 0.08),
-          [-1, 1],
-          [30, 80]
-        )
-      )
+      color={`${ORANGE}${Math.floor(interpolate(Math.sin(localFrame * 0.08), [-1, 1], [30, 80]))
         .toString(16)
         .padStart(2, "0")}`}
       frame={localFrame}
     >
-      <Spinner
-        text={currentSpinner}
-        frame={localFrame}
-        color={DIM}
-      />
+      <Spinner text={currentSpinner} frame={localFrame} color={DIM} />
     </HighlightBox>
   );
 };
@@ -39,15 +29,8 @@ export const SceneWait: React.FC<{ frame: number }> = ({ frame }) => {
     extrapolateRight: "clamp",
   });
 
-  const spinnerTexts = [
-    "Thinking...",
-    "Reading files...",
-    "Analyzing codebase...",
-  ];
-  const currentSpinner =
-    spinnerTexts[
-      Math.floor(localFrame / 40) % spinnerTexts.length
-    ];
+  const spinnerTexts = ["Thinking...", "Reading files...", "Analyzing codebase..."];
+  const currentSpinner = spinnerTexts[Math.floor(localFrame / 40) % spinnerTexts.length];
 
   return (
     <AbsoluteFill
@@ -64,13 +47,8 @@ export const SceneWait: React.FC<{ frame: number }> = ({ frame }) => {
           <span style={{ color: WHITE }}>build me an app</span>
         </div>
         <div style={{ height: 20 }} />
-        <div style={{ color: DIM, fontSize: 18, marginBottom: 16 }}>
-          Claude is working...
-        </div>
-        <WaitHighlight
-          localFrame={localFrame}
-          currentSpinner={currentSpinner}
-        />
+        <div style={{ color: DIM, fontSize: 18, marginBottom: 16 }}>Claude is working...</div>
+        <WaitHighlight localFrame={localFrame} currentSpinner={currentSpinner} />
       </Terminal>
     </AbsoluteFill>
   );

--- a/video/src/scenes/placements/PlacementFrame.tsx
+++ b/video/src/scenes/placements/PlacementFrame.tsx
@@ -7,7 +7,17 @@ export const PlacementFrame: React.FC<{
   children: React.ReactNode;
 }> = ({ o, children }) => {
   return (
-    <div style={{ opacity: o, position: "relative", width: "100%", height: "100%", display: "flex", alignItems: "center", justifyContent: "center" }}>
+    <div
+      style={{
+        opacity: o,
+        position: "relative",
+        width: "100%",
+        height: "100%",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+      }}
+    >
       {children}
     </div>
   );

--- a/video/src/scenes/placements/PlacementSpinnerVerbs.tsx
+++ b/video/src/scenes/placements/PlacementSpinnerVerbs.tsx
@@ -15,7 +15,7 @@ export const PlacementSpinnerVerbs: React.FC<{
     localFrame,
     [0, 5, placementDuration - 5, placementDuration],
     [0, 1, 1, 0],
-    { extrapolateRight: "clamp" }
+    { extrapolateRight: "clamp" },
   );
   return (
     <PlacementFrame o={o}>

--- a/video/src/scenes/placements/PlacementStackAnalysis.tsx
+++ b/video/src/scenes/placements/PlacementStackAnalysis.tsx
@@ -9,11 +9,7 @@ const StackWarning: React.FC<{
   opacity: number;
   children: React.ReactNode;
 }> = ({ opacity, children }) => {
-  return (
-    <div style={{ color: ORANGE, opacity }}>
-      {children}
-    </div>
-  );
+  return <div style={{ color: ORANGE, opacity }}>{children}</div>;
 };
 
 // The three "missing from your stack" lines, in the order they fade in.
@@ -42,12 +38,9 @@ export const PlacementStackAnalysis: React.FC<{
   placementDuration: number;
 }> = ({ localFrame, placementDuration }) => {
   const lf = localFrame - placementDuration * 3;
-  const o = interpolate(
-    lf,
-    [0, 5, placementDuration - 5, placementDuration],
-    [0, 1, 1, 0],
-    { extrapolateRight: "clamp" }
-  );
+  const o = interpolate(lf, [0, 5, placementDuration - 5, placementDuration], [0, 1, 1, 0], {
+    extrapolateRight: "clamp",
+  });
   return (
     <PlacementFrame o={o}>
       <Terminal scale={0.85}>
@@ -80,11 +73,7 @@ export const PlacementStackAnalysis: React.FC<{
           ))}
         </div>
       </Terminal>
-      <Label
-        text="Stack Analysis"
-        frame={lf}
-        startFrame={8}
-      />
+      <Label text="Stack Analysis" frame={lf} startFrame={8} />
     </PlacementFrame>
   );
 };

--- a/video/src/scenes/placements/PlacementStatusLine.tsx
+++ b/video/src/scenes/placements/PlacementStatusLine.tsx
@@ -11,12 +11,9 @@ export const PlacementStatusLine: React.FC<{
   placementDuration: number;
 }> = ({ localFrame, placementDuration }) => {
   const lf = localFrame - placementDuration;
-  const o = interpolate(
-    lf,
-    [0, 5, placementDuration - 5, placementDuration],
-    [0, 1, 1, 0],
-    { extrapolateRight: "clamp" }
-  );
+  const o = interpolate(lf, [0, 5, placementDuration - 5, placementDuration], [0, 1, 1, 0], {
+    extrapolateRight: "clamp",
+  });
   return (
     <PlacementFrame o={o}>
       <Terminal
@@ -25,9 +22,7 @@ export const PlacementStatusLine: React.FC<{
         statusLine="Groq (a16z) \u2014 50x faster LLM inference. Free tier available.  https://groq.com"
         statusLineGlow
       >
-        <div style={{ color: DIM, fontSize: 18 }}>
-          Analyzing API response times...
-        </div>
+        <div style={{ color: DIM, fontSize: 18 }}>Analyzing API response times...</div>
         <div style={{ height: 20 }} />
         <Spinner text="Checking dependencies..." frame={lf} color={DIM} />
       </Terminal>

--- a/video/src/scenes/scale/ScaleDevelopers.tsx
+++ b/video/src/scenes/scale/ScaleDevelopers.tsx
@@ -10,12 +10,7 @@ export const ScaleDevelopers: React.FC<{
 }> = ({ localFrame, left, top }) => {
   return (
     <StatBlock left={left} top={top}>
-      <DotGrid
-        count={400}
-        frame={localFrame}
-        startFrame={0}
-        color={CYAN}
-      />
+      <DotGrid count={400} frame={localFrame} startFrame={0} color={CYAN} />
       <StatCaption
         localFrame={localFrame}
         value="3,000,000+"

--- a/video/src/scenes/scale/ScaleLayers.tsx
+++ b/video/src/scenes/scale/ScaleLayers.tsx
@@ -3,10 +3,7 @@ import { spring } from "remotion";
 import { StatBlock, StatCaption } from "../../components/StatBlock";
 import { ACCENT, CYAN, GREEN, ORANGE } from "../../theme";
 
-const ScaleLayer: React.FC<{ i: number; localFrame: number }> = ({
-  i,
-  localFrame,
-}) => {
+const ScaleLayer: React.FC<{ i: number; localFrame: number }> = ({ i, localFrame }) => {
   const layerDelay = i * 5 + 30;
   const layerProgress = spring({
     frame: Math.max(0, localFrame - layerDelay),

--- a/video/src/scenes/scale/ScalePortfolio.tsx
+++ b/video/src/scenes/scale/ScalePortfolio.tsx
@@ -3,27 +3,13 @@ import { interpolate, spring } from "remotion";
 import { StatBlock, StatCaption } from "../../components/StatBlock";
 import { ACCENT, CYAN, GREEN, ORANGE } from "../../theme";
 
-const PortfolioDot: React.FC<{ i: number; localFrame: number }> = ({
-  i,
-  localFrame,
-}) => {
-  const colors = [
-    CYAN,
-    GREEN,
-    ACCENT,
-    ORANGE,
-    "#f778ba",
-  ];
+const PortfolioDot: React.FC<{ i: number; localFrame: number }> = ({ i, localFrame }) => {
+  const colors = [CYAN, GREEN, ACCENT, ORANGE, "#f778ba"];
   const delay = i * 2;
-  const dotOpacity = interpolate(
-    localFrame - delay,
-    [10, 18],
-    [0, 1],
-    {
-      extrapolateLeft: "clamp",
-      extrapolateRight: "clamp",
-    }
-  );
+  const dotOpacity = interpolate(localFrame - delay, [10, 18], [0, 1], {
+    extrapolateLeft: "clamp",
+    extrapolateRight: "clamp",
+  });
   const dotScale = spring({
     frame: Math.max(0, localFrame - delay - 10),
     fps: 30,


### PR DESCRIPTION
Closes #25

## What
Adds `.oxfmtrc.json` and runs `oxfmt --write` over the code it covers.
Also adds `.github/workflows/oxfmt.yml`, which runs `oxfmt --check` and fails
the job on unformatted code.

Changed here: 36 files, 434 lines.

This is part 2 of 2. The whole reformat is 832 lines across 40 files,
split to stay inside the 500-line PR cap. Each part touches a disjoint set of
files, so the parts do not conflict.

## Why
The 2026-08-31 fleet audit found oxfmt in zero of the 48 pooriaarab repos that
carry JS/TS, against oxlint in 40. One formatter, enforced in CI, removes a class
of review noise that agent-authored diffs generate constantly.

`ignorePatterns` excludes vendor, third_party, generated, minified and build
output. Without it the formatter rewrites dependencies: on foxcade that was
141,361 lines, of which roughly 87,000 were `three.module.js` and `maplibre-gl`.

## How I verified

```
npx oxfmt@0.65.0 --check .                 -> exit 0
npx oxlint@1.80.0 --config .oxlintrc.json  -> exit 0
git diff --numstat main                   -> 36 files, 434 lines
```

No source was hand-edited. Every change is `oxfmt --write` output.

Assisted-by: claude-personal-1:claude-opus-5
