### PR TITLE
[VA-28] Adopt oxfmt as the formatter (part 1/3)

### DIFF
--- a/.oxfmtrc.json
+++ b/.oxfmtrc.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "https://unpkg.com/oxfmt@0.65.0/configuration_schema.json",
+  "ignorePatterns": [
+    "**/vendor/**",
+    "**/third_party/**",
+    "**/generated/**",
+    "**/*.generated.*",
+    "**/*.min.js",
+    "**/*.min.css",
+    "**/*.bundle.js",
+    "**/dist/**",
+    "**/build/**",
+    "**/.next/**",
+    "**/.wrangler/**",
+    "**/.open-next/**",
+    "**/coverage/**"
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -98,28 +98,28 @@ Cleanly removes all hooks from `~/.claude/settings.json` and deletes `~/.vibeads
 
 ## a16z Portfolio Companies (20)
 
-| Company | Category | Speedrun | What They Do |
-|---------|----------|----------|-------------|
-| Clerk | Auth | | Drop-in auth for React/Next.js |
-| PlanetScale | Database | | Serverless MySQL with branching |
-| Stripe | Payments | | Payment infrastructure for 3.1M+ businesses |
-| Replicate | AI Models | | Run open-source ML models via API |
-| Groq | AI Inference | | 50x faster LLM inference via LPU chips |
-| Fal.ai | AI Inference | | Sub-second image generation API |
-| ElevenLabs | Voice AI | | Human-quality AI voice in 29 languages |
-| Mistral | AI Models | | Open-weight LLMs at 70% lower cost |
-| Arcjet | Security | | Rate limiting and bot protection for Node.js |
-| Rork | Mobile | Yes | AI mobile app builder for React Native |
-| Figma | Design | | Collaborative design platform |
-| Stainless | Dev Tools | | Auto-generate type-safe SDKs from OpenAPI |
-| PagerDuty | Monitoring | | Incident management and on-call alerting |
-| Hex | Data | | Collaborative SQL and Python notebooks |
-| Databricks | Data | | Unified lakehouse for ETL, analytics, and ML |
-| Runware | AI API | | Fastest image generation API at scale |
-| Flora AI | Creative | Yes | AI creative design tool |
-| Hedra | Video | | AI talking-head video generation |
-| Cursor | Dev Tools | | AI-native code editor |
-| Replit | Dev Tools | | Cloud IDE with instant deploys |
+| Company     | Category     | Speedrun | What They Do                                 |
+| ----------- | ------------ | -------- | -------------------------------------------- |
+| Clerk       | Auth         |          | Drop-in auth for React/Next.js               |
+| PlanetScale | Database     |          | Serverless MySQL with branching              |
+| Stripe      | Payments     |          | Payment infrastructure for 3.1M+ businesses  |
+| Replicate   | AI Models    |          | Run open-source ML models via API            |
+| Groq        | AI Inference |          | 50x faster LLM inference via LPU chips       |
+| Fal.ai      | AI Inference |          | Sub-second image generation API              |
+| ElevenLabs  | Voice AI     |          | Human-quality AI voice in 29 languages       |
+| Mistral     | AI Models    |          | Open-weight LLMs at 70% lower cost           |
+| Arcjet      | Security     |          | Rate limiting and bot protection for Node.js |
+| Rork        | Mobile       | Yes      | AI mobile app builder for React Native       |
+| Figma       | Design       |          | Collaborative design platform                |
+| Stainless   | Dev Tools    |          | Auto-generate type-safe SDKs from OpenAPI    |
+| PagerDuty   | Monitoring   |          | Incident management and on-call alerting     |
+| Hex         | Data         |          | Collaborative SQL and Python notebooks       |
+| Databricks  | Data         |          | Unified lakehouse for ETL, analytics, and ML |
+| Runware     | AI API       |          | Fastest image generation API at scale        |
+| Flora AI    | Creative     | Yes      | AI creative design tool                      |
+| Hedra       | Video        |          | AI talking-head video generation             |
+| Cursor      | Dev Tools    |          | AI-native code editor                        |
+| Replit      | Dev Tools    |          | Cloud IDE with instant deploys               |
 
 ## How it works (technical)
 

--- a/docs/plans/2026-02-18-vibeads-implementation.md
+++ b/docs/plans/2026-02-18-vibeads-implementation.md
@@ -13,6 +13,7 @@
 ### Task 1: Project Scaffolding
 
 **Files:**
+
 - Create: `package.json`
 - Create: `bin/vibeads.js`
 - Create: `.gitignore`
@@ -28,19 +29,8 @@
   "bin": {
     "vibeads": "./bin/vibeads.js"
   },
-  "files": [
-    "bin/",
-    "src/",
-    "README.md"
-  ],
-  "keywords": [
-    "claude-code",
-    "developer-tools",
-    "a16z",
-    "vibeads",
-    "ads",
-    "hooks"
-  ],
+  "files": ["bin/", "src/", "README.md"],
+  "keywords": ["claude-code", "developer-tools", "a16z", "vibeads", "ads", "hooks"],
   "author": "Pooria Arab",
   "license": "MIT",
   "repository": {
@@ -113,12 +103,14 @@ git commit -m "feat: scaffold vibeads npm package with CLI entry point"
 ### Task 2: Portfolio Data & Keyword Matcher
 
 **Files:**
+
 - Create: `src/data/portfolio.json`
 - Create: `src/matcher/keyword.js`
 
 **Step 1: Create portfolio data with keyword mappings**
 
 Create `src/data/portfolio.json` — this maps context keywords to a16z portfolio companies. Each company has:
+
 - `name`, `oneLiner`, `website`, `category`
 - `keywords`: array of strings that trigger this recommendation
 - `freeTier`: description of free offering (or null)
@@ -128,27 +120,27 @@ Create `src/data/portfolio.json` — this maps context keywords to a16z portfoli
 
 Include these companies with accurate keyword mappings:
 
-| Company | Keywords |
-|---------|----------|
-| Clerk | auth, login, signup, session, jwt, oauth, next-auth, passport, lucia, supabase auth |
-| PlanetScale | mysql, database, db, prisma, drizzle, sequelize, knex, planetscale, vitess |
-| Stripe | payment, billing, checkout, subscription, stripe, paypal, invoice |
-| Replicate | replicate, stable-diffusion, llama, whisper, ml-model, ai-model, huggingface |
-| Groq | groq, llm, inference, fast-api, openai, anthropic, completion, chat-api |
-| Fal.ai | fal, image-gen, text-to-image, midjourney, dalle, flux, stable-diffusion |
-| ElevenLabs | text-to-speech, tts, voice, audio, elevenlabs, speech-synthesis |
-| Mistral | mistral, open-source-llm, self-host, llm, ollama, local-model |
-| Arcjet | rate-limit, bot, security, ddos, waf, middleware, protection, cors |
-| Rork | react-native, expo, mobile-app, ios, android, mobile |
-| Figma | figma, design, ui, ux, prototype, wireframe, mockup |
-| GitHub | github, git, ci, actions, workflow, pipeline |
-| Stainless | sdk, api-client, openapi, swagger, code-gen, type-safe |
-| PagerDuty | alert, incident, on-call, monitoring, uptime, crash |
-| Hex | notebook, data-analysis, sql, pandas, jupyter, data-science |
-| Databricks | spark, data-lake, etl, data-pipeline, warehouse, delta |
-| Runware | image-generation, ai-art, text-to-image, model-api |
-| Flora AI | canvas, creative, design-ai, generative-design |
-| Hedra | video-gen, talking-head, lip-sync, character-animation |
+| Company     | Keywords                                                                            |
+| ----------- | ----------------------------------------------------------------------------------- |
+| Clerk       | auth, login, signup, session, jwt, oauth, next-auth, passport, lucia, supabase auth |
+| PlanetScale | mysql, database, db, prisma, drizzle, sequelize, knex, planetscale, vitess          |
+| Stripe      | payment, billing, checkout, subscription, stripe, paypal, invoice                   |
+| Replicate   | replicate, stable-diffusion, llama, whisper, ml-model, ai-model, huggingface        |
+| Groq        | groq, llm, inference, fast-api, openai, anthropic, completion, chat-api             |
+| Fal.ai      | fal, image-gen, text-to-image, midjourney, dalle, flux, stable-diffusion            |
+| ElevenLabs  | text-to-speech, tts, voice, audio, elevenlabs, speech-synthesis                     |
+| Mistral     | mistral, open-source-llm, self-host, llm, ollama, local-model                       |
+| Arcjet      | rate-limit, bot, security, ddos, waf, middleware, protection, cors                  |
+| Rork        | react-native, expo, mobile-app, ios, android, mobile                                |
+| Figma       | figma, design, ui, ux, prototype, wireframe, mockup                                 |
+| GitHub      | github, git, ci, actions, workflow, pipeline                                        |
+| Stainless   | sdk, api-client, openapi, swagger, code-gen, type-safe                              |
+| PagerDuty   | alert, incident, on-call, monitoring, uptime, crash                                 |
+| Hex         | notebook, data-analysis, sql, pandas, jupyter, data-science                         |
+| Databricks  | spark, data-lake, etl, data-pipeline, warehouse, delta                              |
+| Runware     | image-generation, ai-art, text-to-image, model-api                                  |
+| Flora AI    | canvas, creative, design-ai, generative-design                                      |
+| Hedra       | video-gen, talking-head, lip-sync, character-animation                              |
 
 **Step 2: Create keyword matcher**
 
@@ -160,9 +152,7 @@ import { dirname, join } from "path";
 import { fileURLToPath } from "url";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
-const portfolio = JSON.parse(
-  readFileSync(join(__dirname, "../data/portfolio.json"), "utf-8")
-);
+const portfolio = JSON.parse(readFileSync(join(__dirname, "../data/portfolio.json"), "utf-8"));
 
 /**
  * Match tool context to a16z portfolio company using keyword matching.
@@ -206,8 +196,7 @@ function extractSearchableText(context) {
       // Extract command, file_path, content, pattern from tool input
       if (context.toolInput.command) parts.push(context.toolInput.command);
       if (context.toolInput.file_path) parts.push(context.toolInput.file_path);
-      if (context.toolInput.content)
-        parts.push(context.toolInput.content.slice(0, 500));
+      if (context.toolInput.content) parts.push(context.toolInput.content.slice(0, 500));
       if (context.toolInput.pattern) parts.push(context.toolInput.pattern);
       if (context.toolInput.query) parts.push(context.toolInput.query);
     }
@@ -231,6 +220,7 @@ git commit -m "feat: add a16z portfolio data and keyword matching engine"
 ### Task 3: Impression Tracker
 
 **Files:**
+
 - Create: `src/tracker/impressions.js`
 
 **Step 1: Create impression tracker**
@@ -286,8 +276,7 @@ export function recordImpression(companySlug, tier, context) {
     data.stats[companySlug] = { total: 0, byTier: {}, firstSeen: impression.timestamp };
   }
   data.stats[companySlug].total++;
-  data.stats[companySlug].byTier[tier] =
-    (data.stats[companySlug].byTier[tier] || 0) + 1;
+  data.stats[companySlug].byTier[tier] = (data.stats[companySlug].byTier[tier] || 0) + 1;
   data.stats[companySlug].lastSeen = impression.timestamp;
 
   saveImpressions(data);
@@ -300,9 +289,7 @@ export function getStats() {
   const data = loadImpressions();
   const today = new Date().toISOString().slice(0, 10);
 
-  const todayImpressions = data.impressions.filter((i) =>
-    i.timestamp.startsWith(today)
-  );
+  const todayImpressions = data.impressions.filter((i) => i.timestamp.startsWith(today));
 
   const uniqueCompanies = new Set(data.impressions.map((i) => i.company));
 
@@ -333,6 +320,7 @@ git commit -m "feat: add local impression tracking and stats"
 ### Task 4: Status Line Script (Tier 1)
 
 **Files:**
+
 - Create: `src/statusline.js`
 
 **Step 1: Create status line script**
@@ -384,14 +372,12 @@ function render() {
 
   // Line 1: Company name + one-liner
   console.log(
-    `\x1b[36m${company.name}\x1b[0m\x1b[90m${speedrunBadge} (a16z)\x1b[0m — ${company.statusLineCopy}`
+    `\x1b[36m${company.name}\x1b[0m\x1b[90m${speedrunBadge} (a16z)\x1b[0m — ${company.statusLineCopy}`,
   );
 
   // Line 2: Clickable link using OSC 8
   const url = company.website + "?ref=vibeads";
-  console.log(
-    `\x1b[90m  \x1b]8;;${url}\x07${url}\x1b]8;;\x07\x1b[0m`
-  );
+  console.log(`\x1b[90m  \x1b]8;;${url}\x07${url}\x1b]8;;\x07\x1b[0m`);
 }
 ```
 
@@ -407,6 +393,7 @@ git commit -m "feat: add status line script with clickable OSC 8 links"
 ### Task 5: PostToolUse Hook (Tiers 2-4)
 
 **Files:**
+
 - Create: `src/hooks/post-tool.js`
 
 **Step 1: Create PostToolUse hook script**
@@ -414,6 +401,7 @@ git commit -m "feat: add status line script with clickable OSC 8 links"
 Create `src/hooks/post-tool.js`:
 
 This script:
+
 1. Reads hook JSON from stdin
 2. Runs keyword matching (fast, Tier 1-2)
 3. Writes the current recommendation to `~/.vibeads/current-recommendation.json` for the status line
@@ -471,14 +459,14 @@ function handlePostToolUse(hookInput) {
       company: match,
       trigger: `${hookInput.tool_name}: ${summarizeTrigger(hookInput)}`,
       timestamp: new Date().toISOString(),
-    })
+    }),
   );
 
   // Record impression
   recordImpression(
     match.slug,
     "post-tool",
-    `${hookInput.tool_name}: ${summarizeTrigger(hookInput)}`
+    `${hookInput.tool_name}: ${summarizeTrigger(hookInput)}`,
   );
 
   // Tier 4: Return additionalContext so Claude can mention the tool
@@ -518,6 +506,7 @@ git commit -m "feat: add PostToolUse hook with keyword matching and context inje
 ### Task 6: SessionStart Hook — Stack Analysis (Tier 5)
 
 **Files:**
+
 - Create: `src/hooks/session-start.js`
 
 **Step 1: Create SessionStart hook script**
@@ -525,6 +514,7 @@ git commit -m "feat: add PostToolUse hook with keyword matching and context inje
 Create `src/hooks/session-start.js`:
 
 On session start, this script:
+
 1. Reads `package.json` from the project directory
 2. Scans for common config files (`.env`, `prisma/schema.prisma`, `docker-compose.yml`, etc.)
 3. Builds a tech stack profile
@@ -567,29 +557,22 @@ function handleSessionStart(hookInput) {
   }
 
   // Save stack profile
-  writeFileSync(
-    join(VIBEADS_DIR, "stack-profile.json"),
-    JSON.stringify(stackProfile, null, 2)
-  );
+  writeFileSync(join(VIBEADS_DIR, "stack-profile.json"), JSON.stringify(stackProfile, null, 2));
 
   // Generate recommendations based on stack gaps
   const recommendations = generateRecommendations(stackProfile);
 
   if (recommendations.length > 0) {
     // SessionStart stdout is injected into Claude's context
-    const contextLines = [
-      "[vibeads] Tech stack analysis for this project:",
-    ];
+    const contextLines = ["[vibeads] Tech stack analysis for this project:"];
 
     for (const rec of recommendations.slice(0, 3)) {
       contextLines.push(
-        `  - ${rec.type}: ${rec.message} (${rec.company.name}, a16z${rec.company.speedrun ? " Speedrun" : ""}: ${rec.company.website}?ref=vibeads)`
+        `  - ${rec.type}: ${rec.message} (${rec.company.name}, a16z${rec.company.speedrun ? " Speedrun" : ""}: ${rec.company.website}?ref=vibeads)`,
       );
     }
 
-    contextLines.push(
-      "  Mention these only when directly relevant. Do not force recommendations."
-    );
+    contextLines.push("  Mention these only when directly relevant. Do not force recommendations.");
 
     console.log(contextLines.join("\n"));
   }
@@ -644,36 +627,25 @@ function analyzeStack(cwd) {
 
   // Detect from dependencies
   const deps = Object.keys(profile.dependencies);
-  if (deps.some((d) => d.includes("supabase")))
-    profile.detectedTools.baas = "supabase";
-  if (deps.some((d) => d.includes("firebase")))
-    profile.detectedTools.baas = "firebase";
+  if (deps.some((d) => d.includes("supabase"))) profile.detectedTools.baas = "supabase";
+  if (deps.some((d) => d.includes("firebase"))) profile.detectedTools.baas = "firebase";
   if (deps.includes("next-auth") || deps.includes("@auth/core"))
     profile.detectedTools.auth = "next-auth";
   if (deps.includes("@clerk/nextjs") || deps.includes("@clerk/clerk-sdk-node"))
     profile.detectedTools.auth = "clerk";
   if (deps.includes("stripe") || deps.includes("@stripe/stripe-js"))
     profile.detectedTools.payments = "stripe";
-  if (deps.includes("pg") || deps.includes("mysql2"))
-    profile.detectedTools.database = "raw-sql";
+  if (deps.includes("pg") || deps.includes("mysql2")) profile.detectedTools.database = "raw-sql";
   if (deps.includes("mongoose") || deps.includes("mongodb"))
     profile.detectedTools.database = "mongodb";
 
   // Identify gaps
   if (!profile.detectedTools.auth) profile.gaps.push("auth");
-  if (!profile.detectedTools.database && !profile.detectedTools.baas)
-    profile.gaps.push("database");
+  if (!profile.detectedTools.database && !profile.detectedTools.baas) profile.gaps.push("database");
   if (!profile.detectedTools.payments) profile.gaps.push("payments");
   if (!deps.some((d) => d.includes("sentry") || d.includes("datadog")))
     profile.gaps.push("monitoring");
-  if (
-    !deps.some(
-      (d) =>
-        d.includes("rate-limit") ||
-        d.includes("helmet") ||
-        d.includes("arcjet")
-    )
-  )
+  if (!deps.some((d) => d.includes("rate-limit") || d.includes("helmet") || d.includes("arcjet")))
     profile.gaps.push("security");
 
   return profile;
@@ -702,8 +674,7 @@ function generateRecommendations(profile) {
         website: "https://www.pagerduty.com",
       },
       type: "missing",
-      message:
-        "No monitoring detected. PagerDuty free tier covers 5 users for incident management",
+      message: "No monitoring detected. PagerDuty free tier covers 5 users for incident management",
     },
     security: {
       company: {
@@ -713,8 +684,7 @@ function generateRecommendations(profile) {
         website: "https://arcjet.com",
       },
       type: "missing",
-      message:
-        "No rate limiting or bot protection. Arcjet adds security middleware in 3 lines",
+      message: "No rate limiting or bot protection. Arcjet adds security middleware in 3 lines",
     },
   };
 
@@ -788,6 +758,7 @@ git commit -m "feat: add SessionStart hook with tech stack analysis and gap dete
 ### Task 7: Installer (npx vibeads init)
 
 **Files:**
+
 - Create: `src/install.js`
 - Create: `src/uninstall.js`
 
@@ -858,9 +829,7 @@ export async function init() {
   // PostToolUse hook
   if (!settings.hooks.PostToolUse) settings.hooks.PostToolUse = [];
   // Remove any existing vibeads hooks first
-  settings.hooks.PostToolUse = settings.hooks.PostToolUse.filter(
-    (h) => !isVibeadsHook(h)
-  );
+  settings.hooks.PostToolUse = settings.hooks.PostToolUse.filter((h) => !isVibeadsHook(h));
   settings.hooks.PostToolUse.push({
     matcher: "Bash|Write|Edit|Read",
     hooks: [
@@ -875,9 +844,7 @@ export async function init() {
 
   // SessionStart hook
   if (!settings.hooks.SessionStart) settings.hooks.SessionStart = [];
-  settings.hooks.SessionStart = settings.hooks.SessionStart.filter(
-    (h) => !isVibeadsHook(h)
-  );
+  settings.hooks.SessionStart = settings.hooks.SessionStart.filter((h) => !isVibeadsHook(h));
   settings.hooks.SessionStart.push({
     matcher: "startup|resume",
     hooks: [
@@ -919,7 +886,7 @@ export async function init() {
   if (!existsSync(join(VIBEADS_DIR, "impressions.json"))) {
     writeFileSync(
       join(VIBEADS_DIR, "impressions.json"),
-      JSON.stringify({ impressions: [], stats: {} }, null, 2)
+      JSON.stringify({ impressions: [], stats: {} }, null, 2),
     );
   }
 
@@ -932,9 +899,7 @@ export async function init() {
 }
 
 function isVibeadsHook(hookGroup) {
-  return hookGroup.hooks?.some((h) =>
-    h.command?.includes(".vibeads")
-  );
+  return hookGroup.hooks?.some((h) => h.command?.includes(".vibeads"));
 }
 ```
 
@@ -961,7 +926,7 @@ export async function uninstall() {
     if (settings.hooks) {
       for (const event of Object.keys(settings.hooks)) {
         settings.hooks[event] = settings.hooks[event].filter(
-          (h) => !h.hooks?.some((hook) => hook.command?.includes(".vibeads"))
+          (h) => !h.hooks?.some((hook) => hook.command?.includes(".vibeads")),
         );
         // Clean up empty arrays
         if (settings.hooks[event].length === 0) {
@@ -1003,6 +968,7 @@ git commit -m "feat: add installer and uninstaller for Claude Code hooks"
 ### Task 8: Dashboard
 
 **Files:**
+
 - Create: `src/dashboard.js`
 
 **Step 1: Create dashboard**
@@ -1059,9 +1025,7 @@ export async function dashboard() {
   }
 
   // Show config
-  const config = JSON.parse(
-    readFileSync(join(VIBEADS_DIR, "config.json"), "utf-8")
-  );
+  const config = JSON.parse(readFileSync(join(VIBEADS_DIR, "config.json"), "utf-8"));
   const activeTiers = Object.entries(config.tiers)
     .filter(([, v]) => v)
     .map(([k]) => k);
@@ -1082,6 +1046,7 @@ git commit -m "feat: add CLI dashboard for viewing impressions and stack analysi
 ### Task 9: Portfolio Data File (Complete)
 
 **Files:**
+
 - Create: `src/data/portfolio.json`
 
 **Step 1: Create the complete portfolio data file**
@@ -1094,6 +1059,7 @@ This is the actual data file referenced by the matcher. It must include all a16z
 - `slug`, `name`, `oneLiner`, `website`, `category`, `speedrun`, `freeTier`
 
 Example entry:
+
 ```json
 {
   "slug": "clerk",
@@ -1103,7 +1069,19 @@ Example entry:
   "category": "auth",
   "speedrun": false,
   "freeTier": "Free up to 10,000 monthly active users",
-  "keywords": ["auth", "login", "signup", "session", "jwt", "oauth", "next-auth", "passport", "lucia", "authentication", "clerk"],
+  "keywords": [
+    "auth",
+    "login",
+    "signup",
+    "session",
+    "jwt",
+    "oauth",
+    "next-auth",
+    "passport",
+    "lucia",
+    "authentication",
+    "clerk"
+  ],
   "spinnerCopy": "next-auth: 200+ lines of config. Clerk: 5 lines. Free up to 10K MAU.",
   "statusLineCopy": "Clerk (a16z) -- Drop-in auth for React/Next.js. 5 lines of code. Free up to 10K monthly active users."
 }
@@ -1123,6 +1101,7 @@ git commit -m "feat: add complete a16z portfolio data with keywords and persuasi
 ### Task 10: Fix Import Paths for Installed Hooks
 
 **Files:**
+
 - Modify: `src/hooks/post-tool.js`
 - Modify: `src/hooks/session-start.js`
 
@@ -1131,11 +1110,14 @@ git commit -m "feat: add complete a16z portfolio data with keywords and persuasi
 The hook scripts run from `~/.vibeads/hooks/` after installation, NOT from the npm package directory. The imports need to use relative paths that work from `~/.vibeads/hooks/`:
 
 In `post-tool.js`, change:
+
 ```javascript
 import { matchKeyword } from "../matcher/keyword.js";
 import { recordImpression } from "../tracker/impressions.js";
 ```
+
 to:
+
 ```javascript
 import { matchKeyword } from "../src/matcher/keyword.js";
 import { recordImpression } from "../src/tracker/impressions.js";
@@ -1155,6 +1137,7 @@ git commit -m "fix: correct import paths for installed hook scripts"
 ### Task 11: End-to-End Testing
 
 **Files:**
+
 - None (testing existing code)
 
 **Step 1: Link the package locally**
@@ -1166,6 +1149,7 @@ Run: `npm link`
 Run: `npx vibeads init`
 
 Expected output:
+
 ```
 vibeads -- contextual dev tool discovery for Claude Code
 Powered by a16z portfolio
@@ -1214,11 +1198,13 @@ git commit -m "fix: address issues found during end-to-end testing"
 ### Task 12: README and Publishing Prep
 
 **Files:**
+
 - Create: `README.md`
 
 **Step 1: Write README**
 
 Create a README.md with:
+
 - Project name and one-liner
 - What it does (with terminal screenshot mockup using code blocks)
 - Installation: `npx vibeads init`
@@ -1243,11 +1229,13 @@ git push origin main
 ### Task 13: Final Polish and Demo Prep
 
 **Files:**
+
 - Various small fixes
 
 **Step 1: Re-install and test the full flow**
 
 Run `npx vibeads init`, then start a Claude Code session in a project with a `package.json`. Verify:
+
 - Status line shows recommendations
 - Spinner messages appear during tool use
 - Dashboard shows impressions accumulating

--- a/src/data/portfolio.json
+++ b/src/data/portfolio.json
@@ -8,7 +8,20 @@
       "category": "auth",
       "speedrun": false,
       "freeTier": "Free up to 10,000 monthly active users",
-      "keywords": ["auth", "login", "signup", "session", "jwt", "oauth", "next-auth", "passport", "lucia", "authentication", "clerk", "@clerk"],
+      "keywords": [
+        "auth",
+        "login",
+        "signup",
+        "session",
+        "jwt",
+        "oauth",
+        "next-auth",
+        "passport",
+        "lucia",
+        "authentication",
+        "clerk",
+        "@clerk"
+      ],
       "spinnerCopy": "Add auth in 5 lines with Clerk. Free up to 10K users.",
       "statusLineCopy": "Clerk (a16z) -- Drop-in auth for React/Next.js. 5 lines of code. Free up to 10K monthly active users."
     },
@@ -20,7 +33,17 @@
       "category": "database",
       "speedrun": false,
       "freeTier": "Hobby tier with 5 GB storage and 1B row reads/mo",
-      "keywords": ["mysql", "database", "db", "prisma", "drizzle", "sequelize", "knex", "vitess", "schema"],
+      "keywords": [
+        "mysql",
+        "database",
+        "db",
+        "prisma",
+        "drizzle",
+        "sequelize",
+        "knex",
+        "vitess",
+        "schema"
+      ],
       "spinnerCopy": "Ship schema changes with zero downtime. Try PlanetScale.",
       "statusLineCopy": "PlanetScale (a16z) -- Serverless MySQL with branching and zero-downtime schema changes. Built on Vitess."
     },
@@ -32,7 +55,15 @@
       "category": "payments",
       "speedrun": false,
       "freeTier": "No monthly fee, pay 2.9% + 30c per transaction",
-      "keywords": ["payment", "billing", "checkout", "subscription", "stripe", "invoice", "pricing"],
+      "keywords": [
+        "payment",
+        "billing",
+        "checkout",
+        "subscription",
+        "stripe",
+        "invoice",
+        "pricing"
+      ],
       "spinnerCopy": "Accept payments in 7 lines with Stripe Checkout.",
       "statusLineCopy": "Stripe (a16z) -- Payment infrastructure for 3.1M+ businesses. Checkout in 7 lines of code."
     },
@@ -44,7 +75,15 @@
       "category": "ai-model-hosting",
       "speedrun": false,
       "freeTier": "Free for first predictions, then pay per second of compute",
-      "keywords": ["replicate", "stable-diffusion", "llama", "whisper", "ml-model", "huggingface", "diffusion"],
+      "keywords": [
+        "replicate",
+        "stable-diffusion",
+        "llama",
+        "whisper",
+        "ml-model",
+        "huggingface",
+        "diffusion"
+      ],
       "spinnerCopy": "Run any ML model with one API call. Try Replicate.",
       "statusLineCopy": "Replicate (a16z) -- Run Llama, Stable Diffusion, Whisper with one API call. No GPU setup needed."
     },
@@ -56,7 +95,16 @@
       "category": "ai-inference",
       "speedrun": false,
       "freeTier": "Free tier with rate limits for Llama and Mixtral models",
-      "keywords": ["groq", "llm", "inference", "openai", "anthropic", "completion", "chat-api", "gpt"],
+      "keywords": [
+        "groq",
+        "llm",
+        "inference",
+        "openai",
+        "anthropic",
+        "completion",
+        "chat-api",
+        "gpt"
+      ],
       "spinnerCopy": "Get 50x faster LLM inference with Groq. Free tier available.",
       "statusLineCopy": "Groq (a16z) -- LPU-powered inference. 50x faster than GPU providers. Free tier for Llama and Mixtral."
     },
@@ -68,7 +116,15 @@
       "category": "ai-inference",
       "speedrun": false,
       "freeTier": "Free credits on signup for image generation",
-      "keywords": ["fal", "image-gen", "text-to-image", "midjourney", "dalle", "flux", "image-generation"],
+      "keywords": [
+        "fal",
+        "image-gen",
+        "text-to-image",
+        "midjourney",
+        "dalle",
+        "flux",
+        "image-generation"
+      ],
       "spinnerCopy": "Generate images in under 1 second with Fal.ai.",
       "statusLineCopy": "Fal.ai (a16z) -- Fastest image generation API. Flux in ~1s vs ~12s on DALL-E 3. Free credits on signup."
     },
@@ -92,7 +148,14 @@
       "category": "ai-models",
       "speedrun": false,
       "freeTier": "Open-weight models free to self-host, API with free tier",
-      "keywords": ["mistral", "open-source-llm", "self-host", "ollama", "local-model", "open-weight"],
+      "keywords": [
+        "mistral",
+        "open-source-llm",
+        "self-host",
+        "ollama",
+        "local-model",
+        "open-weight"
+      ],
       "spinnerCopy": "Self-host open-weight LLMs for free with Mistral.",
       "statusLineCopy": "Mistral (a16z) -- Open-weight LLMs rivaling GPT-4. Self-host free or API at 70% lower cost."
     },
@@ -104,7 +167,16 @@
       "category": "security",
       "speedrun": false,
       "freeTier": "Free tier with 10,000 requests/month",
-      "keywords": ["rate-limit", "bot", "security", "ddos", "waf", "middleware", "protection", "helmet"],
+      "keywords": [
+        "rate-limit",
+        "bot",
+        "security",
+        "ddos",
+        "waf",
+        "middleware",
+        "protection",
+        "helmet"
+      ],
       "spinnerCopy": "Add rate limiting and bot protection in 3 lines with Arcjet.",
       "statusLineCopy": "Arcjet (a16z) -- Rate limiting, bot protection, and security for Next.js in 3 lines. Free 10K req/mo."
     },

--- a/src/hooks/session-start.js
+++ b/src/hooks/session-start.js
@@ -31,10 +31,7 @@ function handleSessionStart(hookInput) {
     mkdirSync(VIBEADS_DIR, { recursive: true });
   }
 
-  writeFileSync(
-    join(VIBEADS_DIR, "stack-profile.json"),
-    JSON.stringify(stackProfile, null, 2)
-  );
+  writeFileSync(join(VIBEADS_DIR, "stack-profile.json"), JSON.stringify(stackProfile, null, 2));
 
   const recommendations = generateRecommendations(stackProfile);
 
@@ -62,23 +59,19 @@ function handleSessionStart(hookInput) {
         company: fullCompany,
         trigger: `stack-analysis: ${topRec.type} - ${topRec.message}`,
         timestamp: new Date().toISOString(),
-      })
+      }),
     );
 
     // Output context for Claude
-    const contextLines = [
-      "[vibeads] Tech stack analysis for this project:",
-    ];
+    const contextLines = ["[vibeads] Tech stack analysis for this project:"];
 
     for (const rec of recommendations.slice(0, 3)) {
       contextLines.push(
-        `  - ${rec.type}: ${rec.message} (${rec.company.name}, a16z${rec.company.speedrun ? " Speedrun" : ""}: ${rec.company.website}?ref=vibeads)`
+        `  - ${rec.type}: ${rec.message} (${rec.company.name}, a16z${rec.company.speedrun ? " Speedrun" : ""}: ${rec.company.website}?ref=vibeads)`,
       );
     }
 
-    contextLines.push(
-      "  Mention these only when directly relevant. Do not force recommendations."
-    );
+    contextLines.push("  Mention these only when directly relevant. Do not force recommendations.");
 
     console.log(contextLines.join("\n"));
   }
@@ -144,18 +137,12 @@ const GAP_DETECTORS = [
   { id: "payments", detect: (_deps, tools) => !tools.payments },
   {
     id: "monitoring",
-    detect: (deps) =>
-      !deps.some((d) => d.includes("sentry") || d.includes("datadog")),
+    detect: (deps) => !deps.some((d) => d.includes("sentry") || d.includes("datadog")),
   },
   {
     id: "security",
     detect: (deps) =>
-      !deps.some(
-        (d) =>
-          d.includes("rate-limit") ||
-          d.includes("helmet") ||
-          d.includes("arcjet")
-      ),
+      !deps.some((d) => d.includes("rate-limit") || d.includes("helmet") || d.includes("arcjet")),
   },
 ];
 
@@ -216,7 +203,12 @@ const GAP_RECOMMENDATIONS = {
     message: "No auth detected. Clerk gives you drop-in auth with 10K free MAU",
   },
   monitoring: {
-    company: { name: "PagerDuty", slug: "pagerduty", speedrun: false, website: "https://www.pagerduty.com" },
+    company: {
+      name: "PagerDuty",
+      slug: "pagerduty",
+      speedrun: false,
+      website: "https://www.pagerduty.com",
+    },
     type: "missing",
     message: "No monitoring detected. PagerDuty free tier covers 5 users for incident management",
   },
@@ -234,7 +226,8 @@ const STACK_RECOMMENDATIONS = [
     recommendation: {
       company: { name: "Clerk", slug: "clerk", speedrun: false, website: "https://clerk.com" },
       type: "alternative",
-      message: "Using next-auth? Clerk replaces 200+ lines of auth config with 5 lines. Free up to 10K MAU",
+      message:
+        "Using next-auth? Clerk replaces 200+ lines of auth config with 5 lines. Free up to 10K MAU",
     },
   },
   {
@@ -244,9 +237,15 @@ const STACK_RECOMMENDATIONS = [
       deps.includes("prisma") ||
       deps.includes("drizzle-orm"),
     recommendation: {
-      company: { name: "PlanetScale", slug: "planetscale", speedrun: false, website: "https://planetscale.com" },
+      company: {
+        name: "PlanetScale",
+        slug: "planetscale",
+        speedrun: false,
+        website: "https://planetscale.com",
+      },
       type: "upgrade",
-      message: "PlanetScale: serverless MySQL with non-blocking schema changes. No more migration headaches",
+      message:
+        "PlanetScale: serverless MySQL with non-blocking schema changes. No more migration headaches",
     },
   },
   {

--- a/video/src/scenes/SceneDeadSpace.tsx
+++ b/video/src/scenes/SceneDeadSpace.tsx
@@ -10,21 +10,14 @@ const DeadSpaceCut1: React.FC<{
   localFrame: number;
   cutDuration: number;
 }> = ({ localFrame, cutDuration }) => {
-  const cutOpacity = interpolate(
-    localFrame,
-    [0, 3, cutDuration - 3, cutDuration],
-    [0, 1, 1, 0],
-    { extrapolateRight: "clamp" }
-  );
+  const cutOpacity = interpolate(localFrame, [0, 3, cutDuration - 3, cutDuration], [0, 1, 1, 0], {
+    extrapolateRight: "clamp",
+  });
   return (
     <div style={{ opacity: cutOpacity }}>
       <Terminal scale={0.8}>
         <HighlightBox color={RED} frame={localFrame}>
-          <Spinner
-            text="Thinking..."
-            frame={localFrame}
-            color={DIM}
-          />
+          <Spinner text="Thinking..." frame={localFrame} color={DIM} />
         </HighlightBox>
       </Terminal>
     </div>
@@ -39,21 +32,13 @@ const DeadSpaceCut2: React.FC<{
     localFrame - cutDuration,
     [0, 3, cutDuration - 3, cutDuration],
     [0, 1, 1, 0],
-    { extrapolateRight: "clamp" }
+    { extrapolateRight: "clamp" },
   );
   return (
     <div style={{ opacity: cutOpacity }}>
-      <Terminal
-        scale={0.8}
-        showStatusLine
-        statusLine=""
-      >
+      <Terminal scale={0.8} showStatusLine statusLine="">
         <div style={{ color: DIM }}>
-          <Spinner
-            text="Reading project..."
-            frame={localFrame}
-            color={DIM}
-          />
+          <Spinner text="Reading project..." frame={localFrame} color={DIM} />
         </div>
       </Terminal>
     </div>
@@ -68,14 +53,12 @@ const DeadSpaceCut3: React.FC<{
     localFrame - cutDuration * 2,
     [0, 3, cutDuration - 3, cutDuration],
     [0, 1, 1, 0],
-    { extrapolateRight: "clamp" }
+    { extrapolateRight: "clamp" },
   );
   return (
     <div style={{ opacity: cutOpacity }}>
       <Terminal scale={0.8}>
-        <div style={{ color: DIM, fontSize: 18 }}>
-          Starting session...
-        </div>
+        <div style={{ color: DIM, fontSize: 18 }}>Starting session...</div>
         <div style={{ height: 200 }} />
       </Terminal>
     </div>
@@ -115,26 +98,18 @@ const DeadSpaceCuts: React.FC<{
   cutDuration: number;
 }> = ({ localFrame, cutDuration }) => {
   if (localFrame < cutDuration) {
-    return (
-      <DeadSpaceCut1 localFrame={localFrame} cutDuration={cutDuration} />
-    );
+    return <DeadSpaceCut1 localFrame={localFrame} cutDuration={cutDuration} />;
   }
 
   if (localFrame < cutDuration * 2) {
-    return (
-      <DeadSpaceCut2 localFrame={localFrame} cutDuration={cutDuration} />
-    );
+    return <DeadSpaceCut2 localFrame={localFrame} cutDuration={cutDuration} />;
   }
 
   if (localFrame < cutDuration * 3) {
-    return (
-      <DeadSpaceCut3 localFrame={localFrame} cutDuration={cutDuration} />
-    );
+    return <DeadSpaceCut3 localFrame={localFrame} cutDuration={cutDuration} />;
   }
 
-  return (
-    <DeadSpaceText localFrame={localFrame} cutDuration={cutDuration} />
-  );
+  return <DeadSpaceText localFrame={localFrame} cutDuration={cutDuration} />;
 };
 
 export const SceneDeadSpace: React.FC<{ frame: number }> = ({ frame }) => {


### PR DESCRIPTION
Part of #28

## What
Adds `.oxfmtrc.json` and runs `oxfmt --write` over the code it covers.

Changed here: 6 files, 428 lines.

This is part 1 of 3. The whole reformat is 832 lines across 40 files,
split to stay inside the 500-line PR cap. Each part touches a disjoint set of
files, so the parts do not conflict.

## Why
The 2026-08-31 fleet audit found oxfmt in zero of the 48 pooriaarab repos that
carry JS/TS, against oxlint in 40. One formatter, enforced in CI, removes a class
of review noise that agent-authored diffs generate constantly.

`ignorePatterns` excludes vendor, third_party, generated, minified and build
output. Without it the formatter rewrites dependencies: on foxcade that was
141,361 lines, of which roughly 87,000 were `three.module.js` and `maplibre-gl`.

## How I verified

```
npx oxfmt@0.65.0 --check .                 -> exit 0
npx oxlint@1.80.0 --config .oxlintrc.json  -> exit 0
git diff --numstat main                   -> 6 files, 428 lines
```

No source was hand-edited. Every change is `oxfmt --write` output.

Assisted-by: claude-personal-1:claude-opus-5
