### PR TITLE
[VA-28] Adopt oxfmt as the formatter (part 3/3)

### DIFF
--- a/.github/workflows/oxfmt.yml
+++ b/.github/workflows/oxfmt.yml
@@ -1,0 +1,28 @@
+name: oxfmt
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  format:
+    name: oxfmt --check
+    runs-on: ubicloud-standard-2
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - uses: oven-sh/setup-bun@v2
+
+      - name: Check formatting
+        run: bunx oxfmt@0.65 --check .

--- a/.oxfmtrc.json
+++ b/.oxfmtrc.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "https://unpkg.com/oxfmt@0.65.0/configuration_schema.json",
+  "ignorePatterns": [
+    "**/vendor/**",
+    "**/third_party/**",
+    "**/generated/**",
+    "**/*.generated.*",
+    "**/*.min.js",
+    "**/*.min.css",
+    "**/*.bundle.js",
+    "**/dist/**",
+    "**/build/**",
+    "**/.next/**",
+    "**/.wrangler/**",
+    "**/.open-next/**",
+    "**/coverage/**"
+  ]
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,7 @@
 # AGENTS.md
 
 <!-- pr-standards:start -->
+
 ## Pull requests
 
 One issue. One PR. One concern. Under 500 counted lines.

--- a/SKILL.md
+++ b/SKILL.md
@@ -10,6 +10,7 @@ Contextual dev tool discovery for Claude Code. While Claude Code works, vibeads 
 ## When to Use This Skill
 
 Use this skill when the user:
+
 - Wants to discover relevant developer tools while coding
 - Asks about alternatives to their current tech stack
 - Wants contextual tool recommendations based on their project


### PR DESCRIPTION
Closes #28

## What
Adds `.oxfmtrc.json` and runs `oxfmt --write` over the code it covers.
Also adds `.github/workflows/oxfmt.yml`, which runs `oxfmt --check` and fails
the job on unformatted code.

Changed here: 4 files, 48 lines.

This is part 3 of 3. The whole reformat is 832 lines across 40 files,
split to stay inside the 500-line PR cap. Each part touches a disjoint set of
files, so the parts do not conflict.

## Why
The 2026-08-31 fleet audit found oxfmt in zero of the 48 pooriaarab repos that
carry JS/TS, against oxlint in 40. One formatter, enforced in CI, removes a class
of review noise that agent-authored diffs generate constantly.

`ignorePatterns` excludes vendor, third_party, generated, minified and build
output. Without it the formatter rewrites dependencies: on foxcade that was
141,361 lines, of which roughly 87,000 were `three.module.js` and `maplibre-gl`.

## How I verified

```
npx oxfmt@0.65.0 --check .                 -> exit 0
npx oxlint@1.80.0 --config .oxlintrc.json  -> exit 0
git diff --numstat main                   -> 4 files, 48 lines
```

No source was hand-edited. Every change is `oxfmt --write` output.

Assisted-by: claude-personal-1:claude-opus-5
