### PR TITLE
[VA-40] Scope oxfmt to JavaScript and TypeScript

### DIFF
--- a/.oxfmtrc.json
+++ b/.oxfmtrc.json
@@ -13,6 +13,14 @@
     "**/.next/**",
     "**/.wrangler/**",
     "**/.open-next/**",
-    "**/coverage/**"
+    "**/coverage/**",
+    "**/*.html",
+    "**/*.md",
+    "**/*.mdx",
+    "**/*.json",
+    "**/*.jsonc",
+    "**/*.yml",
+    "**/*.yaml",
+    "**/*.css"
   ]
 }


### PR DESCRIPTION
Closes #40

## What
Replaces `.oxfmtrc.json` with the canonical fleet config, which adds markdown, HTML, JSON, YAML and CSS to `ignorePatterns`.

## Why
oxfmt is a JavaScript formatter, but it also formats `.md`, `.mdx`, `.html`,
`.json`, `.yml` and `.css`. Gating those in CI buys nothing and produces very
large diffs: scoping to JS and TS cut vibenotifications from 1,523 changed lines
across four pull requests to 409 across one, and vibebrand from 2,350 across
eight to 682 across two.

This repo merged its oxfmt adoption before that decision, so it is the only
thing left holding the wider scope. Every repo should run one formatter over one
file set.

## How I verified

```
diff .oxfmtrc.json ~/oxlint-rollout/oxfmtrc.canonical.json  -> identical
npx oxfmt@0.65.0 --check .                                  -> exit 0
git diff --numstat main                                    -> 1 file, 10 lines
```

Narrowing the ignore set cannot un-format anything, so the existing tree stays
clean under the new config.

Assisted-by: claude-personal-1:claude-opus-5


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated formatting exclusions to skip coverage artifacts and selected documentation, JSON, YAML, and CSS files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->