### PR TITLE
[VA-46] Cap vibecodereview council runs at 3

### DIFF
--- a/.github/workflows/vibecodereview.yml
+++ b/.github/workflows/vibecodereview.yml
@@ -13,12 +13,14 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:
+      actions: read
       contents: write
       pull-requests: write
       id-token: write
     steps:
       - uses: pooriaarab/vibecodereview@v1
         with:
+          max_council_runs: 3
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           claude_code_oauth_token_2: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN_2 }}
           github_token: ${{ github.token }}


### PR DESCRIPTION
Closes #46

## What
Add `actions: read` to the vibecodereview job's permissions and set `max_council_runs: 3` in its `with:` block, so the 5-model council caps at 3 runs per branch.

## Why
Without `actions: read` the run-count lookup 403s and the cap never applies, so branches have run the council 8-9 times; capping at 3 roughly halves OpenRouter spend.

## How I verified
`python3 -c "import yaml; yaml.safe_load(open('.github/workflows/vibecodereview.yml'))"` -> exit 0 (valid YAML)
`git diff --stat` -> 1 file changed, 2 insertions

Proof: n/a — CI-config change, no user-visible behaviour.

Assisted-by: claude-personal:claude-opus-4-8