### PR TITLE
[VA-48] Adopt Cursor Cloud environment

### DIFF
--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,0 +1,12 @@
+{
+  "name": "vibeads Cloud Environment",
+  "install": "npm install",
+  "start": "echo 'Environment ready for cloud agents'",
+  "terminals": [
+    {
+      "name": "Verify",
+      "command": "npm test --if-present || npm run lint --if-present || npm run check --if-present || echo 'Add test/lint script'",
+      "description": "Run tests/lint before opening PRs"
+    }
+  ]
+}

--- a/.cursorignore
+++ b/.cursorignore
@@ -1,0 +1,12 @@
+# Keep secrets and large/generated dirs out of agent context
+.env
+.env.local
+.env.*.local
+**/.secrets/**
+**/node_modules/**
+**/.next/**
+**/dist/**
+**/build/**
+**/.wrangler/**
+**/.turbo/**
+**/.venv/**

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@ node_modules/
 .DS_Store
 *.log
 package-lock.json
+# Cursor cloud — local secrets stay local
+.env.local
+.env.*.local

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,3 +34,39 @@ Settings for this repo are in `.github/pr-standards.json`. The standard is at
 https://github.com/pooriaarab/scripts/blob/main/pr-standards.md
 
 <!-- pr-standards:end -->
+
+<!-- cursor-cloud:start -->
+
+## Cloud agents (Cursor)
+
+This repo runs on [Cursor Cloud Agents](https://cursor.com/docs/cloud-agent). Local
+`.env.local` does **not** sync — mirror keys in **Dashboard → Cloud Agents → Secrets**.
+
+| Secret type | Use for |
+|---|---|
+| Runtime Secret | API keys, passwords (hidden from chat/commits) |
+| Environment Variable | Non-sensitive config (URLs, flags) |
+| Build Secret | Private npm/docker registries during install only |
+
+### Install & test
+
+Install command lives in `.cursor/environment.json`. After dashboard setup:
+
+1. **Environments** → link this repo → wait for **Build = Success**
+2. **Secrets** → copy every key from your local `.env.local` / `.env.example`
+3. Run the project's test/lint command before opening a PR (see below)
+
+### Verify before PR
+
+```bash
+npm test --if-present || npm run lint --if-present || npm run check --if-present || echo 'Add test/lint script'
+```
+
+### Pull requests
+
+Follow the fleet PR standard in this repo's `AGENTS.md` (`<!-- pr-standards:start -->` block).
+Cloud agents need push access via Git integration and a successful environment Build.
+
+Setup guide: https://github.com/pooriaarab/scripts/blob/main/cursor-cloud-rollout.md
+
+<!-- cursor-cloud:end -->


### PR DESCRIPTION
Closes #48

## What

Adds Cursor Cloud agent config: `.cursor/environment.json`, `.cursorignore`,
cloud block in `AGENTS.md`, and `.env.example` (if missing).

Install command: `npm install`

## Why

Cloud agents need a saved environment + Build + Dashboard Secrets per repo.
Local `.env.local` does not sync to the cloud.

## How I verified

gh api repos/pooriaarab/vibeads/contents/package.json --jq .name 2>/dev/null || echo config-only -> detected install: npm install

Proof: n/a — config-only rollout; no runtime code changed in this PR.

After merge: cursor.com → Environments → Secrets → Build Success.

Assisted-by: cursor:cursor-cloud-rollout