### PR TITLE
[VA-51] Move public CI off paid runners

### DIFF
--- a/.github/workflows/jscpd.yml
+++ b/.github/workflows/jscpd.yml
@@ -15,7 +15,7 @@ concurrency:
 jobs:
   jscpd:
     name: jscpd (copy-paste detection)
-    runs-on: ubicloud-standard-2
+    runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/oxfmt.yml
+++ b/.github/workflows/oxfmt.yml
@@ -15,7 +15,7 @@ concurrency:
 jobs:
   format:
     name: oxfmt --check
-    runs-on: ubicloud-standard-2
+    runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/pr-standards.yml
+++ b/.github/workflows/pr-standards.yml
@@ -9,12 +9,13 @@ concurrency:
   cancel-in-progress: true
 
 # This job waits on the GitHub API and does no compute, so it takes the
-# smallest runner. Private pooriaarab repos run every job on Ubicloud; the
-# self-hosted fleet is retired and `ubuntu-latest` is not the house default.
+# smallest runner. This repo is public, so that runner is GitHub-hosted
+# `ubuntu-latest` (free). Private pooriaarab repos stay on Ubicloud. The
+# self-hosted fleet is retired. See #51.
 jobs:
   pr-standards:
     name: PR standards
-    runs-on: ubicloud-standard-2
+    runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:
       contents: read

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,6 +5,13 @@
 Read both `.agents/brand.md` and `.agents/design.md` before changing public copy,
 product claims, CLI output, or demo visuals.
 
+## CI runners
+
+This repo is public, so every job runs on GitHub-hosted `ubuntu-latest`.
+Public repos get those runners for free; Ubicloud bills by the minute.
+Private `pooriaarab/*` repos stay on Ubicloud. The Dell fleet is retired.
+Never re-add a self-hosted label. See pooriaarab/scripts#217.
+
 <!-- pr-standards:start -->
 
 ## Pull requests


### PR DESCRIPTION
Closes #51

## What
Switch this public repo's CI from paid Ubicloud runners to free GitHub-hosted `ubuntu-latest`. Reword the pr-standards sizing comment so it still explains why the job takes the smallest runner, and state in AGENTS.md that Ubicloud is for private repos only.

## Why
Public repos get GitHub-hosted runners for free. Ubicloud on vibeads was paying for capacity GitHub already gives away. Leaving the policy silent, or saying every repo uses Ubicloud, would make the next agent revert this. Parent: pooriaarab/scripts#217.

## How I verified

```text
$ gh api /repos/pooriaarab/vibeads --jq .private
false

$ grep -r "runs-on:.*ubicloud" .github/workflows/ || echo "(no matches)"
(no matches)

$ grep -n "runs-on:" .github/workflows/*.yml
.github/workflows/ci.yml:19:    runs-on: ubuntu-latest
.github/workflows/gitleaks.yml:20:    runs-on: ubuntu-latest
.github/workflows/jscpd.yml:18:    runs-on: ubuntu-latest
.github/workflows/oxfmt.yml:18:    runs-on: ubuntu-latest
.github/workflows/oxlint.yml:17:    runs-on: ubuntu-latest
.github/workflows/pr-standards.yml:18:    runs-on: ubuntu-latest
.github/workflows/publish.yml:21:    runs-on: ubuntu-latest
.github/workflows/vibecodereview.yml:13:    runs-on: ubuntu-latest
```

Proof: n/a — YAML `runs-on` and policy wording; no visible UI.

1. This repo is public, and no workflow still names Ubicloud. Commands above.

2. Not applicable, because this PR only touches a public repo. Private repos stay on Ubicloud and are out of scope.

3. The pr-standards comment still says why this job takes the smallest runner (it waits on the GitHub API and does no compute). It now also says this public repo uses free `ubuntu-latest` and private repos stay on Ubicloud.

4. Every workflow job now uses `ubuntu-latest`. See grep above.

5. CI on this PR is green (second pass, observed):

```text
$ gh pr checks 52
CodeRabbit	pass	0		Review completed
PR standards	pass	10s	https://github.com/pooriaarab/vibeads/actions/runs/33701447060/job/100481415540	
gitleaks	pass	7s	https://github.com/pooriaarab/vibeads/actions/runs/33701312885/job/100481045405	
jscpd (copy-paste detection)	pass	8s	https://github.com/pooriaarab/vibeads/actions/runs/33701312822/job/100481014387	
oxfmt --check	pass	9s	https://github.com/pooriaarab/vibeads/actions/runs/33701312870/job/100481014312	
oxlint	pass	44s	https://github.com/pooriaarab/vibeads/actions/runs/33701312896/job/100481014493	
test	pass	11s	https://github.com/pooriaarab/vibeads/actions/runs/33701312874/job/100481014548	
vibecodereview	pass	2m43s	https://github.com/pooriaarab/vibeads/actions/runs/33701312830/job/100481014177
```

6. AGENTS.md now says private repos stay on Ubicloud.

Assisted-by: pi:x-ai/grok-4.6
