### PR TITLE
[VA-53] Roll vibetrace ingest into VCR

### DIFF
--- a/.github/workflows/vibecodereview.yml
+++ b/.github/workflows/vibecodereview.yml
@@ -20,6 +20,8 @@ jobs:
     steps:
       - uses: pooriaarab/vibecodereview@v1
         with:
+          vibetrace_ingest_url: ${{ secrets.VIBETRACE_INGEST_URL }}
+          vibetrace_ingest_token: ${{ secrets.VIBETRACE_INGEST_TOKEN }}
           max_council_runs: 3
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           claude_code_oauth_token_2: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN_2 }}


### PR DESCRIPTION
Closes #53

## What
Adds `vibetrace_ingest_url` and `vibetrace_ingest_token` to `.github/workflows/vibecodereview.yml`.

## Why
So council runs POST traces to the vibetrace ingest Worker instead of dying in RUNNER_TEMP.

## How I verified
gh api repos/pooriaarab/vibeads/contents/.github/workflows/vibecodereview.yml?ref=va-53-vibetrace-ingest-vcr --jq .content | base64 -d | grep -c vibetrace_ingest -> 2

Assisted-by: cursor:composer-2.5
